### PR TITLE
fvars, bin info and zignatures extraction modes + bug fixing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bin2ml"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bin2ml"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ env_logger = "0.10.0"
 thiserror = "1.0.47"
 enum-as-inner = "0.6.0"
 ordered-float = { version = "4.2.0", features = ["serde"] }
+hex = { version = "0.4", features = ["alloc"] }
 
 [dependencies.petgraph]
 version = "0.6.2"

--- a/src/agfj.rs
+++ b/src/agfj.rs
@@ -69,7 +69,7 @@ impl AGFJFunc {
         reg_norm: bool,
     ) -> Option<(String, String)> {
         let mut esil_function = Vec::<String>::new();
-        if self.blocks.len() >= (*min_blocks).into() && self.blocks[0].offset != 1 {
+        if self.blocks.len() >= <u16 as Into<usize>>::into(*min_blocks) && self.blocks[0].offset != 1 {
             for bb in &self.blocks {
                 let esil: Vec<String> = bb.get_esil_bb(reg_norm);
                 for ins in esil.iter() {
@@ -93,7 +93,7 @@ impl AGFJFunc {
         reg_norm: bool,
     ) -> Option<(String, String)> {
         let mut disasm_function = Vec::<String>::new();
-        if self.blocks.len() >= (*min_blocks).into() && self.blocks[0].offset != 1 {
+        if self.blocks.len() >= <u16 as Into<usize>>::into(*min_blocks) && self.blocks[0].offset != 1 {
             for bb in &self.blocks {
                 let disasm: Vec<String> = bb.get_disasm_bb(reg_norm);
                 for ins in disasm.iter() {
@@ -117,7 +117,7 @@ impl AGFJFunc {
         reg_norm: bool,
     ) -> Option<(String, String)> {
         let mut psuedo_function = Vec::<String>::new();
-        if self.blocks.len() >= (*min_blocks).into() && self.blocks[0].offset != 1 {
+        if self.blocks.len() >= <u16 as Into<usize>>::into(*min_blocks) && self.blocks[0].offset != 1 {
             for bb in &self.blocks {
                 let psuedo: Vec<String> = bb.get_psuedo_bb(reg_norm);
                 for ins in psuedo.iter() {
@@ -135,7 +135,7 @@ impl AGFJFunc {
         }
     }
     pub fn create_bb_edge_list(&mut self, min_blocks: &u16) {
-        if self.blocks.len() > (*min_blocks).into() && self.blocks[0].offset != 1 {
+        if self.blocks.len() > <u16 as Into<usize>>::into(*min_blocks) && self.blocks[0].offset != 1 {
             let bb_start_addrs: Vec<i64> = self.blocks.iter().map(|x| x.offset).collect::<Vec<_>>();
             let mut edge_list = Vec::<(u32, u32, u32)>::new();
 
@@ -162,7 +162,7 @@ impl AGFJFunc {
     ) -> Option<Vec<String>> {
         let mut function_instructions = Vec::<Vec<String>>::new();
 
-        if self.blocks.len() >= (*min_blocks).into() {
+        if self.blocks.len() >= <u16 as Into<usize>>::into(*min_blocks) {
             for bb in &self.blocks {
                 if esil {
                     let bb_ins = bb.get_esil_bb(reg_norm);
@@ -257,7 +257,7 @@ impl AGFJFunc {
         reg_norm: bool,
         pairs: bool,
     ) -> Option<Vec<Vec<String>>> {
-        if self.blocks.len() > (*min_blocks).into() && self.blocks[0].offset != 1 {
+        if self.blocks.len() > <u16 as Into<usize>>::into(*min_blocks) && self.blocks[0].offset != 1 {
             self.create_graph_struct_members(min_blocks);
             let disasm_walks = self.dfs_cfg(10, esil, reg_norm, pairs);
             Some(disasm_walks)
@@ -288,7 +288,7 @@ impl AGFJFunc {
         check_or_create_dir(&full_output_path);
 
         // offset != 1 has been added to skip functions with invalid instructions
-        if self.blocks.len() >= (*min_blocks).into() && self.blocks[0].offset != 1 {
+        if self.blocks.len() >= <u16 as Into<usize>>::into(*min_blocks) && self.blocks[0].offset != 1 {
             let bb_start_addrs: Vec<i64> = self.blocks.iter().map(|x| x.offset).collect::<Vec<_>>();
             let mut edge_list = Vec::<(u32, u32, u32)>::new();
 
@@ -393,7 +393,7 @@ impl AGFJFunc {
 
         if !Path::new(&fname_string).is_file() {
             // offset != 1 has been added to skip functions with invalid instructions
-            if self.blocks.len() >= (*min_blocks).into() && self.blocks[0].offset != 1 {
+            if self.blocks.len() >= <u16 as Into<usize>>::into(*min_blocks) && self.blocks[0].offset != 1 {
                 let mut edge_list = Vec::<(u32, u32, u32)>::new();
 
                 let mut feature_vecs: StringOrF64 = match feature_type {

--- a/src/extract.rs
+++ b/src/extract.rs
@@ -424,7 +424,7 @@ impl ExtractionJob {
                 "localvar-xrefs" => Ok(ExtractionJobType::LocalVariableXrefs),
                 "strings" => Ok(ExtractionJobType::GlobalStrings),
                 "bytes" => Ok(ExtractionJobType::FunctionBytes),
-                "zignatures" => Ok(ExtractionJobType::FunctionZignatures),
+                "zigs" => Ok(ExtractionJobType::FunctionZignatures),
                 _ => bail!("Incorrect command type - got {}", mode),
             }
         }
@@ -603,7 +603,7 @@ impl FileToBeProcessed {
             ExtractionJobType::PCodeBB => "pcode-bb",
             ExtractionJobType::LocalVariableXrefs => "localvar-xrefs",
             ExtractionJobType::GlobalStrings => "strings",
-            ExtractionJobType::FunctionZignatures => "zignatures",
+            ExtractionJobType::FunctionZignatures => "zigs",
             ExtractionJobType::FunctionBytes => "bytes",
         }
         .to_string()

--- a/src/extract.rs
+++ b/src/extract.rs
@@ -1289,8 +1289,11 @@ impl FileToBeProcessed {
         // Build the directory name by combining the file stem with the given suffix.
         let dir_name = format!("{}_{}", file_stem, dirname_suffix);
         output_dir.push(&dir_name);
-        fs::create_dir_all(&output_dir)
-            .with_context(|| format!("Failed to create directory {:?}", output_dir))?;
+
+        if !output_dir.is_dir() {
+            fs::create_dir_all(&output_dir)
+                .with_context(|| format!("Failed to create directory {:?}", output_dir))?;
+        }
         
         // Construct the full output file path.
         let mut output_filepath = output_dir.clone();
@@ -1309,9 +1312,11 @@ impl FileToBeProcessed {
             return Ok(());
         }
 
+        debug!("Attempting to write function bytes to {:?}", output_filepath);
+
         // Write the file and attach context on error.
-        fs::write(&output_dir, func_bytes)
-            .with_context(|| format!("Failed to write file {:?}", output_dir))?;
+        fs::write(&output_filepath, func_bytes)
+            .with_context(|| format!("Failed to write file {:?}", output_filepath))?;
 
         Ok(())
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -285,7 +285,8 @@ enum Commands {
         #[arg(short, long, value_name = "EXTRACT_MODE",
         value_parser = clap::builder::PossibleValuesParser::new([
         "finfo", "fvars", "reg", "cfg", "func-xrefs", "cg", "decomp",
-        "pcode-func", "pcode-bb", "localvar-xrefs", "strings", "bytes"
+        "pcode-func", "pcode-bb", "localvar-xrefs", "strings", "bytes", 
+        "zignatures"
         ])
         .map(|s| s.parse::<String>().unwrap()),
         num_args = 1..,

--- a/src/main.rs
+++ b/src/main.rs
@@ -284,8 +284,7 @@ enum Commands {
         #[arg(short, long, value_name = "EXTRACT_MODE",
         value_parser = clap::builder::PossibleValuesParser::new([
         "finfo", "fvars", "reg", "cfg", "func-xrefs", "cg", "decomp",
-        "pcode-func", "pcode-bb", "localvar-xrefs", "strings", "bytes", 
-        "zignatures"
+        "pcode-func", "pcode-bb", "localvar-xrefs", "strings", "bytes", "zigs"
         ])
         .map(|s| s.parse::<String>().unwrap()),
         num_args = 1..,

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,7 +40,6 @@ pub mod utils;
 mod validate;
 
 use crate::dedup::{CGCorpus, EsilFuncStringCorpus};
-use crate::extract::ExtractionJobType;
 use crate::files::{AFIJFile, AGCJFile, FunctionMetadataTypes, TikNibFuncMetaFile};
 use crate::tokeniser::{train_byte_bpe_tokeniser, TokeniserType};
 use crate::utils::get_save_file_path;

--- a/src/main.rs
+++ b/src/main.rs
@@ -283,7 +283,7 @@ enum Commands {
         /// The extraction modes (multiple can be specified)
         #[arg(short, long, value_name = "EXTRACT_MODE",
         value_parser = clap::builder::PossibleValuesParser::new([
-        "finfo", "fvars", "reg", "cfg", "func-xrefs", "cg", "decomp",
+        "bininfo", "finfo", "fvars", "reg", "cfg", "func-xrefs", "cg", "decomp",
         "pcode-func", "pcode-bb", "localvar-xrefs", "strings", "bytes", "zigs"
         ])
         .map(|s| s.parse::<String>().unwrap()),

--- a/src/main.rs
+++ b/src/main.rs
@@ -284,7 +284,7 @@ enum Commands {
         /// The extraction modes (multiple can be specified)
         #[arg(short, long, value_name = "EXTRACT_MODE",
         value_parser = clap::builder::PossibleValuesParser::new([
-        "finfo", "reg", "cfg", "func-xrefs", "cg", "decomp",
+        "finfo", "fvars", "reg", "cfg", "func-xrefs", "cg", "decomp",
         "pcode-func", "pcode-bb", "localvar-xrefs", "strings", "bytes"
         ])
         .map(|s| s.parse::<String>().unwrap()),

--- a/src/main.rs
+++ b/src/main.rs
@@ -271,19 +271,26 @@ enum Commands {
         subcommands: GenerateSubCommands,
     },
     /// Extract raw data from input binaries
+    /// Extract raw data from input binaries
     Extract {
         /// The path to the dir or binary to be processed
         #[arg(short, long, value_name = "DIR")]
         fpath: PathBuf,
 
         /// The path for the output directory
-        #[arg(short, long, value_name = "DIR")]
+        #[arg(short, long, value_name = "OUTPUT_DIR")]
         output_dir: PathBuf,
 
-        /// The extraction mode
-        #[arg(short, long, value_name = "EXTRACT_MODE", value_parser = clap::builder::PossibleValuesParser::new(["finfo", "reg", "cfg", "func-xrefs","cg", "decomp", "pcode-func", "pcode-bb", "localvar-xrefs", "strings", "bytes"])
-        .map(|s| s.parse::<String>().unwrap()),)]
-        mode: String,
+        /// The extraction modes (multiple can be specified)
+        #[arg(short, long, value_name = "EXTRACT_MODE",
+        value_parser = clap::builder::PossibleValuesParser::new([
+        "finfo", "reg", "cfg", "func-xrefs", "cg", "decomp",
+        "pcode-func", "pcode-bb", "localvar-xrefs", "strings", "bytes"
+        ])
+        .map(|s| s.parse::<String>().unwrap()),
+        num_args = 1..,
+        required = true)]
+        modes: Vec<String>,
 
         /// The number of threads Rayon can use when parallel processing
         #[arg(short, long, value_name = "NUM_THREADS", default_value = "2")]
@@ -1022,156 +1029,67 @@ fn main() {
         Commands::Extract {
             fpath,
             output_dir,
-            mode,
+            modes,
             num_threads,
             debug,
             extended_analysis,
             use_curl_pdb,
             with_annotations,
         } => {
-            info!("Creating extraction job");
+            info!("Creating extraction job with {} modes", modes.len());
             if !output_dir.exists() {
                 error!("Output directory does not exist - {:?}. Create the directory and re-run again. Exiting...", output_dir);
                 exit(1)
             }
+
+            // Create a single extraction job with all modes
             let job = ExtractionJob::new(
                 fpath,
                 output_dir,
-                mode,
+                modes,
                 debug,
                 extended_analysis,
                 use_curl_pdb,
                 with_annotations,
             )
-            .unwrap();
+            .unwrap_or_else(|e| {
+                error!("Failed to create extraction job: {}", e);
+                exit(1);
+            });
+
+            info!(
+                "Created extraction job with {} job types",
+                job.job_types.len()
+            );
 
             if job.input_path_type == PathType::Dir {
                 info!("Directory found - will parallel process");
 
-                info!("Creating thread pool with {} threads ", num_threads);
+                info!("Creating thread pool with {} threads", num_threads);
                 rayon::ThreadPoolBuilder::new()
                     .num_threads(*num_threads)
                     .build_global()
                     .unwrap();
 
-                if job.job_type == ExtractionJobType::CFG {
-                    info!("Extraction Job Type: CFG");
-                    info!("Starting Parallel generation.");
-                    #[allow(clippy::redundant_closure)]
-                    job.files_to_be_processed
-                        .par_iter()
-                        .progress()
-                        .for_each(|path| path.extract_func_cfgs());
-                } else if job.job_type == ExtractionJobType::RegisterBehaviour {
-                    info!("Extraction Job Type: Register Behaviour");
-                    info!("Starting Parallel generation.");
-                    #[allow(clippy::redundant_closure)]
-                    job.files_to_be_processed
-                        .par_iter()
-                        .progress()
-                        .for_each(|path| path.extract_register_behaviour());
-                } else if job.job_type == ExtractionJobType::FunctionXrefs {
-                    info!("Extraction Job Type: Function Xrefs");
-                    info!("Starting Parallel generation.");
-                    #[allow(clippy::redundant_closure)]
-                    job.files_to_be_processed
-                        .par_iter()
-                        .progress()
-                        .for_each(|path| path.extract_function_xrefs());
-                } else if job.job_type == ExtractionJobType::CallGraphs {
-                    info!("Extraction Job Type: Call Graphs");
-                    info!("Starting Parallel generation.");
-                    #[allow(clippy::redundant_closure)]
-                    job.files_to_be_processed
-                        .par_iter()
-                        .progress()
-                        .for_each(|path| path.extract_function_call_graphs());
-                } else if job.job_type == ExtractionJobType::FuncInfo {
-                    info!("Extraction Job Type: Function Info");
-                    info!("Starting Parallel generation.");
-                    #[allow(clippy::redundant_closure)]
-                    job.files_to_be_processed
-                        .par_iter()
-                        .progress()
-                        .for_each(|path| path.extract_function_info());
-                } else if job.job_type == ExtractionJobType::Decompilation {
-                    info!("Extraction Job Type: Decompilation");
-                    info!("Starting Parallel generation.");
-                    #[allow(clippy::redundant_closure)]
-                    job.files_to_be_processed
-                        .par_iter()
-                        .progress()
-                        .for_each(|path| path.extract_decompilation());
-                } else if job.job_type == ExtractionJobType::PCodeFunc {
-                    info!("Extraction Job Type: PCode Function");
-                    info!("Starting Parallel generation.");
-                    #[allow(clippy::redundant_closure)]
-                    job.files_to_be_processed
-                        .par_iter()
-                        .progress()
-                        .for_each(|path| path.extract_pcode_function());
-                } else if job.job_type == ExtractionJobType::PCodeBB {
-                    info!("Extraction Job Type: PCode Basic Block");
-                    info!("Starting Parallel generation.");
-                    #[allow(clippy::redundant_closure)]
-                    job.files_to_be_processed
-                        .par_iter()
-                        .progress()
-                        .for_each(|path| path.extract_pcode_basic_block());
-                } else if job.job_type == ExtractionJobType::LocalVariableXrefs {
-                    info!("Extraction Job Type: Local Variable Xrefs");
-                    info!("Starting Parallel generation.");
-                    #[allow(clippy::redundant_closure)]
-                    job.files_to_be_processed
-                        .par_iter()
-                        .progress()
-                        .for_each(|path| path.extract_local_variable_xrefs());
-                } else if job.job_type == ExtractionJobType::GlobalStrings {
-                    job.files_to_be_processed
-                        .par_iter()
-                        .progress()
-                        .for_each(|path| path.extract_global_strings());
-                } else if job.job_type == ExtractionJobType::FunctionBytes {
-                    job.files_to_be_processed
-                        .par_iter()
-                        .progress()
-                        .for_each(|path| path.extract_function_bytes());
-                };
+                // Process all files in parallel, each file processes all modes with a single r2pipe
+                job.files_to_be_processed
+                    .par_iter()
+                    .progress()
+                    .for_each(|path| path.process_all_modes());
             } else if job.input_path_type == PathType::File {
                 info!("Single file found");
-                if job.job_type == ExtractionJobType::CFG {
-                    info!("Extraction Job Type: CFG");
-                    job.files_to_be_processed[0].extract_func_cfgs();
-                } else if job.job_type == ExtractionJobType::RegisterBehaviour {
-                    info!("Extraction Job Type: Register Behaviour");
-                    job.files_to_be_processed[0].extract_register_behaviour()
-                } else if job.job_type == ExtractionJobType::FunctionXrefs {
-                    info!("Extraction Job type: Function Xrefs");
-                    job.files_to_be_processed[0].extract_function_xrefs()
-                } else if job.job_type == ExtractionJobType::CallGraphs {
-                    info!("Extraction Job type: Function Call Graphs");
-                    job.files_to_be_processed[0].extract_function_call_graphs()
-                } else if job.job_type == ExtractionJobType::FuncInfo {
-                    info!("Extraction Job type: Function Info");
-                    job.files_to_be_processed[0].extract_function_info()
-                } else if job.job_type == ExtractionJobType::Decompilation {
-                    info!("Extraction Job type: Decompilation");
-                    job.files_to_be_processed[0].extract_decompilation()
-                } else if job.job_type == ExtractionJobType::PCodeFunc {
-                    job.files_to_be_processed[0].extract_pcode_function()
-                } else if job.job_type == ExtractionJobType::PCodeBB {
-                    job.files_to_be_processed[0].extract_pcode_basic_block()
-                } else if job.job_type == ExtractionJobType::LocalVariableXrefs {
-                    job.files_to_be_processed[0].extract_local_variable_xrefs()
-                } else if job.job_type == ExtractionJobType::GlobalStrings {
-                    job.files_to_be_processed[0].extract_global_strings()
-                } else if job.job_type == ExtractionJobType::FunctionBytes {
-                    job.files_to_be_processed[0].extract_function_bytes()
-                } else {
-                    error!("Unsupported ExtractionJobType of {:?}", job.job_type)
-                }
-                info!("Extraction complete for {:?}", fpath)
+
+                // Process single file with all modes using a single r2pipe instance
+                job.files_to_be_processed[0].process_all_modes();
+
+                info!(
+                    "Extraction complete for {:?} with {} modes",
+                    fpath,
+                    modes.len()
+                );
             }
+
+            info!("All extractions completed");
         }
 
         #[cfg(feature = "inference")]


### PR DESCRIPTION
This PR covers all of the excellent contributions from PR #27  from [valbucci](https://github.com/valbucci).

### Added extraction modes
- fvars (in radare2 with `afvj`) - `fvars`
- zignatures (in radare2 with `zg` and `zj`) - `zigs`
- binary info (in radare2 with `it` and `itg`) - `bininfo`


### Fixed bugs
- Fixed E0283 by adding type annotations to agfj.rs.
- Changes to "bytes" extraction mode:
    - Extract all function bytes, rather than fixed buffer of 256 bytes.
        - Replaced `pcs @ <func_addr>` with `p8 <func_size>`.
    - Sanitize function names to make a valid path when storing them to a file.
        - In some rare cases it could cause an error when a function name contained, e.g. `:` character.
        - The regular expression `[^\w.-]` is used to identify non-valid characters. These are then replaced with `_`.
            - Note: while very unlikely, this could cause name collision. In that case a debug message will be logged and the colliding function will be skipped.
- Removed unused import `extract::ExtractionJobType` from main.rs.

### Helper Functions
- Added function `sanitize_function_name`.
- Moved JSON fixing logic to helper function `fix_json_object`.