### PR TITLE
Input path matching

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ serde_json = "1.0.60"
 clap = { version = "4.0.29", features = ["derive"] }
 goblin = { version = "0.6.0", optional = true }
 walkdir = "2"
+glob = "0.3.1"
 rayon = "1.6"
 anyhow = "1.0"
 serde_with = "2.2.0"

--- a/src/extract.rs
+++ b/src/extract.rs
@@ -733,51 +733,6 @@ impl FileToBeProcessed {
         .to_string()
     }
 
-    pub fn data_extracter_single(&self, job_type: &ExtractionJobType) {
-        info!("Starting extraction for {:?}", job_type);
-        let mut r2p = self.setup_r2_pipe();
-
-        let job_type_suffix = self.get_job_type_suffix(job_type);
-
-        match job_type {
-            ExtractionJobType::BinInfo => {
-                self.extract_binary_info(&mut r2p, job_type_suffix)
-            }
-            ExtractionJobType::RegisterBehaviour => {
-                self.extract_register_behaviour(&mut r2p, job_type_suffix)
-            }
-            ExtractionJobType::FunctionXrefs => {
-                self.extract_function_xrefs(&mut r2p, job_type_suffix)
-            }
-            ExtractionJobType::CFG => self.extract_func_cfgs(&mut r2p, job_type_suffix),
-            ExtractionJobType::CallGraphs => {
-                self.extract_function_call_graphs(&mut r2p, job_type_suffix)
-            }
-            ExtractionJobType::FuncInfo => self.extract_function_info(&mut r2p, job_type_suffix),
-            ExtractionJobType::FunctionVariables => self.extract_function_variables(&mut r2p, job_type_suffix),
-            ExtractionJobType::Decompilation => {
-                self.extract_decompilation(&mut r2p, job_type_suffix)
-            }
-            ExtractionJobType::PCodeFunc => self.extract_pcode_function(&mut r2p, job_type_suffix),
-            ExtractionJobType::PCodeBB => self.extract_pcode_basic_block(&mut r2p, job_type_suffix),
-            ExtractionJobType::LocalVariableXrefs => {
-                self.extract_local_variable_xrefs(&mut r2p, job_type_suffix)
-            }
-            ExtractionJobType::GlobalStrings => {
-                self.extract_global_strings(&mut r2p, job_type_suffix)
-            }
-            ExtractionJobType::FunctionZignatures => {
-                self.extract_function_zignatures(&mut r2p, job_type_suffix)
-            },
-            ExtractionJobType::FunctionBytes => {
-                self.extract_function_bytes(&mut r2p, job_type_suffix)
-            }
-        }
-
-        r2p.close();
-        info!("r2p closed");
-    }
-
     pub fn extract_binary_info(&self, r2p: &mut R2Pipe, job_type_suffix: String) {
         info!("Starting binary information extraction");
         let bininfo_json = r2p.cmd("ij")
@@ -918,7 +873,6 @@ impl FileToBeProcessed {
                         "Unable to parse json for {}: {}: {}",
                         fp_filename, json_raw, e
                     );
-                    // Here, you can choose to return, skip the operation, or take other action.
                 }
             }
         } else {


### PR DESCRIPTION
Provide a match pattern as input path.

### Extract Example
`bin2ml extract -f "/path/to/input_dir/*.pe64" -o path/to/output_dir -m cfg`

### Generate Example
`cargo run generate graphs -p "/path/to/input_dir/*_cfg.json" -d cfg -o /path/to/output_dir -f gemini -n 2`
> **Note:** Currently only works with the option `-d cfg`