### PR TITLE
Bininfo bug fix

### DIFF
--- a/src/extract.rs
+++ b/src/extract.rs
@@ -415,7 +415,7 @@ pub struct CoreEntry {
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct BinEntry {
     pub arch: String,
-    pub baddr: u64,
+    pub baddr: Option<u64>,
     pub binsz: u64,
     pub bintype: String,
     pub bits: u16,

--- a/src/extract.rs
+++ b/src/extract.rs
@@ -436,7 +436,7 @@ pub struct BinEntry {
     pub guid: String,
     pub intrp: String,
     pub laddr: u64,
-    pub lang: String,
+    pub lang: Option<String>,
     pub linenum: bool,
     pub lsyms: bool,
     pub machine: String,

--- a/src/extract.rs
+++ b/src/extract.rs
@@ -393,9 +393,9 @@ pub struct FunctionZignature {
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ChecksumsEntry {
     // Output of itj
-    md5: String,
-    sha1: String,
-    sha256: String,
+    md5: Option<String>,
+    sha1: Option<String>,
+    sha256: Option<String>,
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]


### PR DESCRIPTION
Sometimes the "bin" entry is missing from the output of r2's `ij`.

To solve this issue, the following changes were implemented:
- Made "bin" entry optional.
- Moved "checksums" entry (populated with `itj`) to the top-level dictionary.