### PR TITLE
Optimisation of `agfj @@f` parsing

### DIFF
--- a/src/extract.rs
+++ b/src/extract.rs
@@ -415,7 +415,7 @@ pub struct CoreEntry {
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct BinEntry {
     pub arch: String,
-    pub baddr: u64,
+    pub baddr: Option<u64>,
     pub binsz: u64,
     pub bintype: String,
     pub bits: u16,

--- a/src/extract.rs
+++ b/src/extract.rs
@@ -393,9 +393,9 @@ pub struct FunctionZignature {
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ChecksumsEntry {
     // Output of itj
-    md5: String,
-    sha1: String,
-    sha256: String,
+    md5: Option<String>,
+    sha1: Option<String>,
+    sha256: Option<String>,
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/src/extract.rs
+++ b/src/extract.rs
@@ -1285,7 +1285,14 @@ impl FileToBeProcessed {
     fn fix_json_object(&self, json_raw: &str) -> Result<serde_json::Value, serde_json::Error> {
         // Collect all JSON objects into a vector.
         let stream = Deserializer::from_str(json_raw).into_iter::<Value>();
-        let json_objects: Result<Vec<Value>, _> = stream.collect();
+        let json_objects: Result<Vec<Value>, _> = stream
+        .filter_map(|result| {
+            match result {
+                Ok(Value::Array(ref arr)) if arr.is_empty() => None, // skip empty arrays
+                other => Some(other),
+            }
+        })
+        .collect();
         // Map the collected vector into a JSON array.
         json_objects.map(Value::Array)
     }


### PR DESCRIPTION
Previously, `agfj @@f` was fixed up with regex substitutions. This could sometimes lead to JSON parsing errors in some rare edge cases.

This PR updates the `fix_json_object` function ([see extract.rs:1285](https://github.com/valbucci/bin2ml/blob/cbc506488c6beb47d6c2beec5b49ecdd45d03a16/src/extract.rs#L1285)) by using `serde_json::Deserialize`. This simplifies the code and improves robustness.  