### PR TITLE
Fixed bug in BinaryInfo checksums

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,9 @@ thiserror = "1.0.47"
 enum-as-inner = "0.6.0"
 ordered-float = { version = "4.2.0", features = ["serde"] }
 hex = { version = "0.4", features = ["alloc"] }
+md5 = "0.7.0"
+sha1 = "0.10.6"
+sha2 = "0.10.8"
 
 [dependencies.petgraph]
 version = "0.6.2"


### PR DESCRIPTION
I don't know why, but sometimes the output of the radare2 command `itj` is just an empty dictionary.

I now updated the code so that the relevant rust crates are used to compute the various hash checksums.