### PR TITLE
Add support for r2 timeout

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,9 @@ thiserror = "1.0.47"
 enum-as-inner = "0.6.0"
 ordered-float = { version = "4.2.0", features = ["serde"] }
 hex = { version = "0.4", features = ["alloc"] }
+md5 = "0.7.0"
+sha1 = "0.10.6"
+sha2 = "0.10.8"
 
 [dependencies.petgraph]
 version = "0.6.2"

--- a/src/extract.rs
+++ b/src/extract.rs
@@ -81,6 +81,7 @@ pub struct R2PipeConfig {
     pub debug: bool,
     pub extended_analysis: bool,
     pub use_curl_pdb: bool,
+    pub timeout: Option<u64>,
 }
 
 impl std::fmt::Display for ExtractionJob {
@@ -478,6 +479,7 @@ impl ExtractionJob {
         debug: &bool,
         extended_analysis: &bool,
         use_curl_pdb: &bool,
+        timeout: &Option<u64>,
         with_annotations: &bool,
     ) -> Result<ExtractionJob, Error> {
         fn get_path_type(bin_path: &PathBuf) -> PathType {
@@ -538,6 +540,7 @@ impl ExtractionJob {
             debug: *debug,
             extended_analysis: *extended_analysis,
             use_curl_pdb: *use_curl_pdb,
+            timeout: *timeout,
         };
 
         let p_type = get_path_type(input_path);
@@ -1552,6 +1555,11 @@ impl FileToBeProcessed {
             None => R2Pipe::spawn(self.file_path.to_str().unwrap(), Some(opts))
                 .expect("Failed to spawn new R2Pipe"),
         };
+
+        if let Some(timeout) = self.r2p_config.timeout {
+            r2p.cmd(format!("e anal.timeout={}", timeout).as_str())
+                .expect("Failed to set timeout");
+        }
 
         if self.r2p_config.use_curl_pdb {
             let info = r2p.cmdj("ij");

--- a/src/main.rs
+++ b/src/main.rs
@@ -271,7 +271,6 @@ enum Commands {
         subcommands: GenerateSubCommands,
     },
     /// Extract raw data from input binaries
-    /// Extract raw data from input binaries
     Extract {
         /// The path to the dir or binary to be processed
         #[arg(short, long, value_name = "DIR")]
@@ -304,6 +303,9 @@ enum Commands {
 
         #[arg(long, default_value = "false")]
         use_curl_pdb: bool,
+
+        #[arg(long)]
+        timeout: Option<u64>,
 
         #[arg(long, default_value = "false")]
         with_annotations: bool,
@@ -1053,6 +1055,7 @@ fn main() {
             debug,
             extended_analysis,
             use_curl_pdb,
+            timeout,
             with_annotations,
         } => {
             info!("Creating extraction job with {} modes", modes.len());
@@ -1069,6 +1072,7 @@ fn main() {
                 debug,
                 extended_analysis,
                 use_curl_pdb,
+                timeout,
                 with_annotations,
             )
             .unwrap_or_else(|e| {


### PR DESCRIPTION
When analysing some malware samples they may use evasion tactics to hang the analysis with r2.

I added the --timeout option to prevent the radare2 analysis to hang. This uses the command `e anal.timeout=3600` -- e.g. for a timeout of 1 hour.

> **Note**: One important thing that is missing is a warning message when timeout was triggered.