### PR TITLE
Default to X86 architecture for ACFG generation

### DIFF
--- a/src/files.rs
+++ b/src/files.rs
@@ -324,14 +324,14 @@ impl AGFJFile {
     /// Generate Attributed Control Flow Graph (ACFG)'s for each of the functions
     /// within an AGFJFile.
     pub fn paralell_attributed_cfg_gen(self) {
+        let arch = self.architecture.as_ref();
+        if arch.is_none() {
+            warn!(
+                "Architecture not detected for {:?}. Using X86 as default.",
+                self.filename
+            );
+        }
         self.functions.unwrap().par_iter().for_each(|func| {
-            let arch = self.architecture.as_ref();
-            if arch.is_none() {
-                warn!(
-                    "Architecture not detected for {:?}. Using X86 as default.",
-                    self.filename
-                );
-            }
             func[0].generate_attributed_cfg(
                 &self.filename,
                 &self.min_blocks,

--- a/src/files.rs
+++ b/src/files.rs
@@ -325,12 +325,19 @@ impl AGFJFile {
     /// within an AGFJFile.
     pub fn paralell_attributed_cfg_gen(self) {
         self.functions.unwrap().par_iter().for_each(|func| {
+            let arch = self.architecture.as_ref();
+            if arch.is_none() {
+                warn!(
+                    "Architecture not detected for {:?}. Using X86 as default.",
+                    self.filename
+                );
+            }
             func[0].generate_attributed_cfg(
                 &self.filename,
                 &self.min_blocks,
                 &self.output_path,
                 self.feature_type.unwrap(),
-                self.architecture.as_ref().unwrap(),
+                arch.unwrap_or(&"X86".to_string()),
             )
         });
     }


### PR DESCRIPTION
I have some very small C files that I compiled for testing purposes. The issue is that their CPU architecture is not detected in `src/files.rs`. Therefore, there was a [breaking error in `paralell_attributed_cfg_gen`](https://github.com/br0kej/bin2ml/blob/c0e68c310dab3873572e0d8c3d948d1e1bf47ca4/src/files.rs#L333) due to the architecture being set to None.

I updated the function to use X86 as default architecture.

I'm marking this PR as ready for review, but I think that potentially it would be better to have this as a default return value in `detect_architecture`. I opted to place this as a separate check in order to keep track of files where the architecture was not detected.

---
I'm attaching [one of the failing CFG files](https://github.com/user-attachments/files/19809045/c_combined_operations_ELF_AMD64_dynamic_stripped_cfg.json). For context, this data was extracted using r2's commit version `e1c82586ea`.