### PR TITLE
Function file name sanitisation

### DIFF
--- a/src/afij.rs
+++ b/src/afij.rs
@@ -8,7 +8,7 @@ use serde_json::Value;
 pub struct AFIJFunctionInfo {
     pub offset: u64,
     pub name: String,
-    pub size: i128,
+    pub size: u64,
     #[serde(rename = "is-pure")]
     pub is_pure: String,
     pub realsz: u64,
@@ -23,21 +23,21 @@ pub struct AFIJFunctionInfo {
     pub nbbs: u64,
     #[serde(rename = "is-lineal")]
     pub is_lineal: bool,
-    pub ninstrs: i64,
-    pub edges: i64,
+    pub ninstrs: u64,
+    pub edges: u64,
     pub ebbs: u64,
     pub signature: String,
     pub minbound: u64,
-    pub maxbound: i128,
+    pub maxbound: u64,
     pub callrefs: Option<Vec<Callref>>,
     // TODO: Need to fix this and change to string instead of i64 to get round large random numbers
     pub datarefs: Option<Vec<Dataref>>,
     pub codexrefs: Option<Vec<Codexref>>,
-    pub dataxrefs: Option<Vec<i64>>,
-    pub indegree: Option<i64>,
-    pub outdegree: Option<i64>,
-    pub nlocals: Option<i64>,
-    pub nargs: Option<i64>,
+    pub dataxrefs: Option<Vec<i64>>, // TODO: Check this data type
+    pub indegree: Option<u64>,
+    pub outdegree: Option<u64>,
+    pub nlocals: Option<u64>,
+    pub nargs: Option<u64>,
     pub bpvars: Option<Vec<Bpvar>>,
     // Cannot find a good example of an spvars yet
     pub spvars: Option<Vec<Value>>,
@@ -103,12 +103,12 @@ pub struct Regvar {
 #[serde(rename_all = "camelCase")]
 pub struct AFIJFeatureSubset {
     pub name: String,
-    pub ninstrs: i64,
-    pub edges: i64,
-    pub indegree: i64,
-    pub outdegree: i64,
-    pub nlocals: i64,
-    pub nargs: i64,
+    pub ninstrs: u64,
+    pub edges: u64,
+    pub indegree: u64,
+    pub outdegree: u64,
+    pub nlocals: u64,
+    pub nargs: u64,
     pub signature: String,
 }
 
@@ -130,12 +130,12 @@ impl From<&AFIJFunctionInfo> for AFIJFeatureSubset {
 #[derive(Default, Debug, Clone, PartialEq, Hash, Serialize, Deserialize)]
 pub struct AFIJFeatureSubsetExtended {
     pub name: String,
-    pub ninstrs: i64,
-    pub edges: i64,
-    pub indegree: i64,
-    pub outdegree: i64,
-    pub nlocals: i64,
-    pub nargs: i64,
+    pub ninstrs: u64,
+    pub edges: u64,
+    pub indegree: u64,
+    pub outdegree: u64,
+    pub nlocals: u64,
+    pub nargs: u64,
     pub nbbs: u64,
     pub avg_ins_bb: OrderedFloat<f32>,
 }

--- a/src/agcj.rs
+++ b/src/agcj.rs
@@ -3,7 +3,7 @@ use crate::networkx::{
     CallGraphFuncNameNode, CallGraphFuncWithMetadata, CallGraphTikNibFeatures,
     CallGraphTikNibFinfoFeatures, NetworkxDiGraph,
 };
-use crate::utils::{check_or_create_dir, get_save_file_path};
+use crate::utils::{check_or_create_dir, get_save_file_path, sanitize_filename};
 use itertools::Itertools;
 use petgraph::prelude::Graph;
 use serde::{Deserialize, Serialize};
@@ -14,14 +14,14 @@ use std::path::{Path, PathBuf};
 #[serde(rename_all = "camelCase")]
 pub struct AGCJFunctionCallGraph {
     pub name: String,
-    pub size: i64,
+    pub size: u64,
     pub imports: Option<Vec<String>>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct AGCJParsedObjects {
     pub edge_property: String,
-    pub edges: Vec<Vec<i32>>,
+    pub edges: Vec<Vec<u32>>,
     pub node_holes: Vec<String>,
     pub nodes: Vec<String>,
 }
@@ -45,10 +45,7 @@ impl AGCJFunctionCallGraph {
 
         let mut function_name = self.name.clone();
 
-        // This is a pretty dirty fix and may break things
-        if function_name.chars().count() > 100 {
-            function_name = self.name[..75].to_string();
-        }
+        function_name = sanitize_filename(&function_name);
 
         let filename = format!("{}-{}.json", function_name, type_suffix);
 
@@ -82,11 +79,7 @@ impl AGCJFunctionCallGraph {
         check_or_create_dir(&full_output_path);
 
         let mut function_name = self.name.clone();
-
-        // This is a pretty dirty fix and may break things
-        if function_name.chars().count() > 100 {
-            function_name = self.name[..75].to_string();
-        }
+        function_name = sanitize_filename(&function_name);
 
         let filename = format!(
             "{}/{}-{}.json",
@@ -121,11 +114,7 @@ impl AGCJFunctionCallGraph {
         check_or_create_dir(&full_output_path);
 
         let mut function_name = self.name.clone();
-
-        // This is a pretty dirty fix and may break things
-        if function_name.chars().count() > 100 {
-            function_name = self.name[..75].to_string();
-        }
+        function_name = sanitize_filename(&function_name);
 
         let filename = format!(
             "{}/{}-{}.json",
@@ -159,11 +148,7 @@ impl AGCJFunctionCallGraph {
         check_or_create_dir(&full_output_path);
         debug!("Built Path: {:?}", full_output_path);
         let mut function_name = self.name.clone();
-
-        // This is a pretty dirty fix and may break things
-        if function_name.chars().count() > 100 {
-            function_name = self.name[..75].to_string();
-        }
+        function_name = sanitize_filename(&function_name);
 
         let filename = format!("{}-{}.json", function_name, type_suffix);
         // Normalise string for windows

--- a/src/combos.rs
+++ b/src/combos.rs
@@ -133,11 +133,11 @@ impl ComboJob {
 #[derive(Default, Hash, PartialEq, Clone, Debug, Deserialize, Serialize)]
 pub struct FinfoTiknib {
     pub name: String,
-    pub edges: i64,
-    pub indegree: i64,
-    pub outdegree: i64,
-    pub nlocals: i64,
-    pub nargs: i64,
+    pub edges: u64,
+    pub indegree: u64,
+    pub outdegree: u64,
+    pub nlocals: u64,
+    pub nargs: u64,
     pub avg_arithshift: OrderedFloat<f32>,
     pub avg_compare: OrderedFloat<f32>,
     pub avg_ctransfer: OrderedFloat<f32>,

--- a/src/extract.rs
+++ b/src/extract.rs
@@ -959,7 +959,7 @@ impl FileToBeProcessed {
             let job_type_suffix = ExtractionJob::get_job_type_suffix(job_type);
             let output_path = self.get_output_filepath(&job_type_suffix).unwrap();
             if Path::new(&output_path).exists() {
-                warn!(
+                debug!(
                     "Skipping {:?} job for {:?}: already processed at {:?}.",
                     job_type_suffix, self.file_path, output_path
                 );

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,7 +59,7 @@ use inference::inference;
 #[cfg(feature = "inference")]
 use processors::agfj_graph_embedded_feats;
 use processors::agfj_graph_statistical_features;
-use utils::get_json_paths_from_dir;
+use utils::{get_json_paths_from_dir, validate_func_filename};
 
 #[global_allocator]
 static GLOBAL: MiMalloc = MiMalloc;
@@ -303,6 +303,15 @@ enum Commands {
 
         #[arg(long, default_value = "false")]
         use_curl_pdb: bool,
+
+        /// Name function data files using symbol, address, or custom template
+        #[arg(
+            long,
+            value_name = "TEMPLATE",
+            default_value = "symbol",
+            value_parser = validate_func_filename
+        )]
+        func_filename: String,
 
         #[arg(long)]
         timeout: Option<u64>,
@@ -1055,6 +1064,7 @@ fn main() {
             debug,
             extended_analysis,
             use_curl_pdb,
+            func_filename,
             timeout,
             with_annotations,
         } => {
@@ -1072,6 +1082,7 @@ fn main() {
                 debug,
                 extended_analysis,
                 use_curl_pdb,
+                func_filename,
                 timeout,
                 with_annotations,
             )

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,6 +1,6 @@
+use regex::Regex;
 use std::fs::create_dir_all;
 use std::path::{Path, PathBuf};
-use regex::Regex;
 use walkdir::WalkDir;
 
 /// Formats a save file path
@@ -85,7 +85,10 @@ pub fn validate_func_filename(s: &str) -> Result<String, String> {
     } else if s.contains("{symbol}") || s.contains("{address}") {
         Ok(s.to_string())
     } else {
-        Err("must be `symbol`, `address`, or a pattern containing `{symbol}`/`{address}`".to_string())
+        Err(
+            "must be `symbol`, `address`, or a pattern containing `{symbol}`/`{address}`"
+                .to_string(),
+        )
     }
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,5 +1,6 @@
 use std::fs::create_dir_all;
 use std::path::{Path, PathBuf};
+use regex::Regex;
 use walkdir::WalkDir;
 
 /// Formats a save file path
@@ -85,6 +86,23 @@ pub fn validate_func_filename(s: &str) -> Result<String, String> {
         Ok(s.to_string())
     } else {
         Err("must be `symbol`, `address`, or a pattern containing `{symbol}`/`{address}`".to_string())
+    }
+}
+
+/// Sanitize name for an output file
+///
+/// This function sanitizes a file name by replacing non-valid characters with '_'.
+pub fn sanitize_filename(name: &str) -> String {
+    // Replace non-valid characters with '_'
+    // Valid characters: letters, digits, '_', '-', and '.'
+    let re = Regex::new(r"[^\w.-]").unwrap();
+    let sanitized_name = re.replace_all(name, "_").into_owned();
+
+    // This is a pretty dirty fix and may break things
+    if sanitized_name.len() > 100 {
+        sanitized_name[..50].to_string() + &sanitized_name[sanitized_name.len() - 50..]
+    } else {
+        sanitized_name
     }
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -74,6 +74,20 @@ pub fn get_save_file_path(
     }
 }
 
+/// Validate the function filename template
+///
+/// This function validates the function filename template to ensure it is a valid template.
+/// The template must be a string containing `{symbol}` or `{address}`.
+pub fn validate_func_filename(s: &str) -> Result<String, String> {
+    if s == "symbol" || s == "address" {
+        Ok(s.to_string())
+    } else if s.contains("{symbol}") || s.contains("{address}") {
+        Ok(s.to_string())
+    } else {
+        Err("must be `symbol`, `address`, or a pattern containing `{symbol}`/`{address}`".to_string())
+    }
+}
+
 /// Get the JSON paths from a directory
 ///
 /// This function takes a path to a directory and traverses all


### PR DESCRIPTION
# File name sanitization
There used to is a bug described in issue #45 where if a function's name is too long the data extraction and generation will fail. 

This fix checks if file names are longer than 100 characters and, if so, they are truncated such that the leading+trailing 50 characters are retained to avoid duplication, and the ones in the middle are removed. For example, a function named: 
- `sym.slices.siftDownCmpFunc_go.shape.interface__Info____io_fs.FileInfo__error___IsDir___bo
ol__Name___string__Type___io_fs.FileMode` (129 characters)
- is renamed to ...
- `sym.slices.siftDownCmpFunc_go.shape.interface__InfIsDir___bool__Name___string__Type___io_fs.FileMode`

There is a function called `sanitize_filename` (see [src/utils.rs:L95](https://github.com/valbucci/bin2ml/blob/887c7df36224a85d11b02f330b040c41b825f891/src/utils.rs#L95)), which replaces all invalid characters with `_` and performs the bidirectional truncation described above.

In the extract mode I added an option `--func-filename` with allows options "symbol" (default), "address", or a custom template. This only works with the `bytes` mode since it's the only one that extracts function-level data files. 

For example, a function called `main0` at address `0xdeadbeef` will be extracted with the following file names, depending on the specified option:

<table>
<thead>
<td><b>Option</b></td><td><b>Filename</b></td>
</thead>

<tr>
   <td><code>symbol</code></td><td><code>main0.bin</code></td>
</tr>
<tr>
  <td><code>address</code></td><td><code>deadbeef.bin</code></td>
</tr>
<tr>
  <td><code>{address}.{symbol}</code></td><td><code>deadbeef.main0</code></td>
</tr>
<tr>
  <td><code>func-{symbol}.bin</code></td><td><code>func-main0.bin</code></td>
</tr>

</table>


It would be nice to have this functionality in bin2ml generate as well, but it would entail a performance reduction during the feature extraction process -- e.g. it would be necessary to run multiple commands for each function instead of `agCj @@f`.

# Secondary changes
I also made some other secondary changes.

- I added `FunctionToBeProcessed` (see [extract.rs:L706](https://github.com/valbucci/bin2ml/blob/887c7df36224a85d11b02f330b040c41b825f891/src/extract.rs#L706)) to hold all the function-related logic such as getters and the byte extraction script.
  - It's easy to convert from `AFIJFunctionInfo` and `AFLJFuncDetails` (see [extract.rs:L1182](https://github.com/valbucci/bin2ml/blob/887c7df36224a85d11b02f330b040c41b825f891/src/extract.rs#L1182) and [L1200](https://github.com/valbucci/bin2ml/blob/887c7df36224a85d11b02f330b040c41b825f891/src/extract.rs#L1200))
- I updated `extraction_job_matcher` and `get_job_type_suffix` such that they are based on a single source of truth (see HashMap in [extract.rs:L60](https://github.com/valbucci/bin2ml/blob/887c7df36224a85d11b02f330b040c41b825f891/src/extract.rs#L60))
- I changed some struct data types from signed integers to unsigned integers where appropriate -- function size, or number of edges.