### PR TITLE
Split CFG extraction into multiple files

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ rust_search = "2.1.0"
 tch = {version = "0.10.3", optional = true}
 mimalloc = { version = "*", default-features = false }
 indicatif = { version = "0.17.3", features = ["rayon"]}
+indicatif-log-bridge = "0.2.3"
 itertools = "0.10.5"
 prettytable = "0.10.0"
 serde-aux = "4.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ tokenizers = "0.13.2"
 rust_search = "2.1.0"
 tch = {version = "0.10.3", optional = true}
 mimalloc = { version = "*", default-features = false }
-indicatif = { version = "0.17.3", features = ["rayon"]}
+indicatif = { version = "0.17.11", features = ["rayon"]}
 indicatif-log-bridge = "0.2.3"
 itertools = "0.10.5"
 prettytable = "0.10.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ tokenizers = "0.13.2"
 rust_search = "2.1.0"
 tch = {version = "0.10.3", optional = true}
 mimalloc = { version = "*", default-features = false }
-indicatif = { version = "0.17.11", features = ["rayon"]}
+indicatif = { version = "0.18.0", features = ["rayon"]}
 indicatif-log-bridge = "0.2.3"
 itertools = "0.10.5"
 prettytable = "0.10.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 r2pipe = "0.6.0"
 serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0.60"
+serde_json = { version = "1.0.60", features = ["raw_value"] }
 clap = { version = "4.0.29", features = ["derive"] }
 goblin = { version = "0.6.0", optional = true }
 walkdir = "2"

--- a/src/afij.rs
+++ b/src/afij.rs
@@ -8,7 +8,7 @@ use serde_json::Value;
 pub struct AFIJFunctionInfo {
     pub offset: u64,
     pub name: String,
-    pub size: i128,
+    pub size: u64,
     #[serde(rename = "is-pure")]
     pub is_pure: String,
     pub realsz: u64,
@@ -23,21 +23,21 @@ pub struct AFIJFunctionInfo {
     pub nbbs: u64,
     #[serde(rename = "is-lineal")]
     pub is_lineal: bool,
-    pub ninstrs: i64,
-    pub edges: i64,
+    pub ninstrs: u64,
+    pub edges: u64,
     pub ebbs: u64,
     pub signature: String,
     pub minbound: u64,
-    pub maxbound: i128,
+    pub maxbound: u64,
     pub callrefs: Option<Vec<Callref>>,
     // TODO: Need to fix this and change to string instead of i64 to get round large random numbers
     pub datarefs: Option<Vec<Dataref>>,
     pub codexrefs: Option<Vec<Codexref>>,
-    pub dataxrefs: Option<Vec<i64>>,
-    pub indegree: Option<i64>,
-    pub outdegree: Option<i64>,
-    pub nlocals: Option<i64>,
-    pub nargs: Option<i64>,
+    pub dataxrefs: Option<Vec<i64>>, // TODO: Check this data type
+    pub indegree: Option<u64>,
+    pub outdegree: Option<u64>,
+    pub nlocals: Option<u64>,
+    pub nargs: Option<u64>,
     pub bpvars: Option<Vec<Bpvar>>,
     // Cannot find a good example of an spvars yet
     pub spvars: Option<Vec<Value>>,
@@ -103,12 +103,12 @@ pub struct Regvar {
 #[serde(rename_all = "camelCase")]
 pub struct AFIJFeatureSubset {
     pub name: String,
-    pub ninstrs: i64,
-    pub edges: i64,
-    pub indegree: i64,
-    pub outdegree: i64,
-    pub nlocals: i64,
-    pub nargs: i64,
+    pub ninstrs: u64,
+    pub edges: u64,
+    pub indegree: u64,
+    pub outdegree: u64,
+    pub nlocals: u64,
+    pub nargs: u64,
     pub signature: String,
 }
 
@@ -130,12 +130,12 @@ impl From<&AFIJFunctionInfo> for AFIJFeatureSubset {
 #[derive(Default, Debug, Clone, PartialEq, Hash, Serialize, Deserialize)]
 pub struct AFIJFeatureSubsetExtended {
     pub name: String,
-    pub ninstrs: i64,
-    pub edges: i64,
-    pub indegree: i64,
-    pub outdegree: i64,
-    pub nlocals: i64,
-    pub nargs: i64,
+    pub ninstrs: u64,
+    pub edges: u64,
+    pub indegree: u64,
+    pub outdegree: u64,
+    pub nlocals: u64,
+    pub nargs: u64,
     pub nbbs: u64,
     pub avg_ins_bb: OrderedFloat<f32>,
 }

--- a/src/afij.rs
+++ b/src/afij.rs
@@ -28,7 +28,9 @@ pub struct AFIJFunctionInfo {
     pub edges: u64,
     pub ebbs: u64,
     pub signature: String,
+    #[serde(alias = "minaddr")]
     pub minbound: u64,
+    #[serde(alias = "maxaddr")]
     pub maxbound: u64,
     pub callrefs: Option<Vec<Callref>>,
     // TODO: Need to fix this and change to string instead of i64 to get round large random numbers

--- a/src/afij.rs
+++ b/src/afij.rs
@@ -6,6 +6,7 @@ use serde_json::Value;
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AFIJFunctionInfo {
+    #[serde(alias = "addr")]
     pub offset: u64,
     pub name: String,
     pub size: u64,

--- a/src/agcj.rs
+++ b/src/agcj.rs
@@ -3,7 +3,7 @@ use crate::networkx::{
     CallGraphFuncNameNode, CallGraphFuncWithMetadata, CallGraphTikNibFeatures,
     CallGraphTikNibFinfoFeatures, NetworkxDiGraph,
 };
-use crate::utils::{check_or_create_dir, get_save_file_path};
+use crate::utils::{check_or_create_dir, get_save_file_path, sanitize_filename};
 use itertools::Itertools;
 use petgraph::prelude::Graph;
 use serde::{Deserialize, Serialize};
@@ -14,14 +14,14 @@ use std::path::{Path, PathBuf};
 #[serde(rename_all = "camelCase")]
 pub struct AGCJFunctionCallGraph {
     pub name: String,
-    pub size: i64,
+    pub size: u64,
     pub imports: Option<Vec<String>>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct AGCJParsedObjects {
     pub edge_property: String,
-    pub edges: Vec<Vec<i32>>,
+    pub edges: Vec<Vec<u32>>,
     pub node_holes: Vec<String>,
     pub nodes: Vec<String>,
 }
@@ -45,10 +45,7 @@ impl AGCJFunctionCallGraph {
 
         let mut function_name = self.name.clone();
 
-        // This is a pretty dirty fix and may break things
-        if function_name.chars().count() > 100 {
-            function_name = self.name[..75].to_string();
-        }
+        function_name = sanitize_filename(&function_name);
 
         let filename = format!("{}-{}.json", function_name, type_suffix);
 
@@ -82,11 +79,7 @@ impl AGCJFunctionCallGraph {
         check_or_create_dir(&full_output_path);
 
         let mut function_name = self.name.clone();
-
-        // This is a pretty dirty fix and may break things
-        if function_name.chars().count() > 100 {
-            function_name = self.name[..75].to_string();
-        }
+        function_name = sanitize_filename(&function_name);
 
         let filename = format!(
             "{}/{}-{}.json",
@@ -121,11 +114,7 @@ impl AGCJFunctionCallGraph {
         check_or_create_dir(&full_output_path);
 
         let mut function_name = self.name.clone();
-
-        // This is a pretty dirty fix and may break things
-        if function_name.chars().count() > 100 {
-            function_name = self.name[..75].to_string();
-        }
+        function_name = sanitize_filename(&function_name);
 
         let filename = format!(
             "{}/{}-{}.json",
@@ -159,11 +148,7 @@ impl AGCJFunctionCallGraph {
         check_or_create_dir(&full_output_path);
         debug!("Built Path: {:?}", full_output_path);
         let mut function_name = self.name.clone();
-
-        // This is a pretty dirty fix and may break things
-        if function_name.chars().count() > 100 {
-            function_name = self.name[..75].to_string();
-        }
+        function_name = sanitize_filename(&function_name);
 
         let filename = format!("{}-{}.json", function_name, type_suffix);
         // Normalise string for windows

--- a/src/agfj.rs
+++ b/src/agfj.rs
@@ -35,15 +35,15 @@ struct EdgePair {
     wt: u16,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct AGFJFunc {
     pub name: String,
-    nargs: u64,
-    ninstr: u64,
-    nlocals: u64,
     #[serde(alias = "addr")]
-    offset: u64,
-    size: Option<u64>,
+    pub offset: u64,
+    pub size: u64,
+    pub ninstr: u64,
+    nargs: u64,
+    nlocals: u64,
     stack: u64,
     r#type: String,
     pub blocks: Vec<ACFJBlock>,
@@ -794,7 +794,7 @@ mod tests {
         assert_eq!(file.functions.as_ref().unwrap()[0][0].ninstr, 78);
         assert_eq!(file.functions.as_ref().unwrap()[0][0].nargs, 2);
         assert_eq!(file.functions.as_ref().unwrap()[0][0].nlocals, 0);
-        assert_eq!(file.functions.as_ref().unwrap()[0][0].size, Some(334));
+        assert_eq!(file.functions.as_ref().unwrap()[0][0].size, 334);
         assert_eq!(file.functions.as_ref().unwrap()[0][0].stack, 56);
         assert!(!file.functions.as_ref().unwrap()[0][0].blocks.is_empty());
 

--- a/src/agfj.rs
+++ b/src/agfj.rs
@@ -813,7 +813,10 @@ mod tests {
         assert!(!file.functions.as_ref().unwrap()[0][0].blocks[0]
             .ops
             .is_empty());
-        assert_eq!(file.functions.as_ref().unwrap()[0][0].blocks[0].fail, get_default_addr());
+        assert_eq!(
+            file.functions.as_ref().unwrap()[0][0].blocks[0].fail,
+            get_default_addr()
+        );
 
         assert!(file.functions.as_ref().unwrap()[0][0].blocks[0]
             .switchop

--- a/src/agfj.rs
+++ b/src/agfj.rs
@@ -41,12 +41,13 @@ pub struct AGFJFunc {
     nargs: u64,
     ninstr: u64,
     nlocals: u64,
+    #[serde(alias = "addr")]
     offset: u64,
     size: Option<u64>,
     stack: u64,
     r#type: String,
     pub blocks: Vec<ACFJBlock>,
-    addr_idx: Option<Vec<i64>>,
+    addr_idx: Option<Vec<u64>>,
     pub edge_list: Option<Vec<(u32, u32, u32)>>,
     graph: Option<Graph<String, u32>>,
 }
@@ -143,7 +144,7 @@ impl AGFJFunc {
     pub fn create_bb_edge_list(&mut self, min_blocks: &u16) {
         if self.blocks.len() > <u16 as Into<usize>>::into(*min_blocks) && self.blocks[0].offset != 1
         {
-            let bb_start_addrs: Vec<i64> = self.blocks.iter().map(|x| x.offset).collect::<Vec<_>>();
+            let bb_start_addrs: Vec<u64> = self.blocks.iter().map(|x| x.offset).collect::<Vec<_>>();
             let mut edge_list = Vec::<(u32, u32, u32)>::new();
 
             for bb in &self.blocks {
@@ -423,7 +424,7 @@ impl AGFJFunc {
                     }
                 };
 
-                let bb_start_addrs: Vec<i64> =
+                let bb_start_addrs: Vec<u64> =
                     self.blocks.iter().map(|x| x.offset).collect::<Vec<_>>();
 
                 match feature_type {
@@ -606,7 +607,7 @@ impl AGFJFunc {
     }
 
     // Convert string memory address to hex / string
-    fn str_to_hex_node_idxs(graph: &mut Graph<String, u32>, addr_idxs: &[i64]) {
+    fn str_to_hex_node_idxs(graph: &mut Graph<String, u32>, addr_idxs: &[u64]) {
         for idx in graph.node_indices() {
             let i_idx = idx.index();
             let hex = addr_idxs[i_idx];
@@ -732,6 +733,7 @@ impl From<(&String, Vec<TikNibFeaturesBB>)> for TikNibFunc {
 #[cfg(test)]
 mod tests {
     use crate::bb::FeatureType;
+    use crate::utils::get_default_addr;
     use std::path::PathBuf;
 
     use crate::AGFJFile;
@@ -811,7 +813,7 @@ mod tests {
         assert!(!file.functions.as_ref().unwrap()[0][0].blocks[0]
             .ops
             .is_empty());
-        assert_eq!(file.functions.as_ref().unwrap()[0][0].blocks[0].fail, -1);
+        assert_eq!(file.functions.as_ref().unwrap()[0][0].blocks[0].fail, get_default_addr());
 
         assert!(file.functions.as_ref().unwrap()[0][0].blocks[0]
             .switchop

--- a/src/bb.rs
+++ b/src/bb.rs
@@ -2,6 +2,7 @@ use crate::consts::*;
 #[cfg(feature = "inference")]
 use crate::inference::InferenceJob;
 use crate::normalisation::{normalise_disasm_simple, normalise_esil_simple};
+use crate::utils::get_default_addr;
 use serde::{Deserialize, Serialize};
 use serde_aux::prelude::*;
 use serde_json::Value;
@@ -58,8 +59,9 @@ pub enum InstructionMode {
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct SwitchOpCase {
-    pub jump: i64,
-    pub offset: i64,
+    pub jump: u64,
+    #[serde(alias = "addr")]
+    pub offset: u64,
     #[serde(deserialize_with = "deserialize_string_from_number")]
     // This will make it challenging to use downstream but has been
     // added because sometimes it is a VERY large int (bigger than i64).
@@ -74,6 +76,7 @@ pub struct SwitchOp {
     pub defval: u16,
     pub maxval: u16,
     pub minval: u16,
+    #[serde(alias = "addr")]
     pub offset: u64,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -86,6 +89,7 @@ pub struct Op {
     pub fcn_addr: Option<u64>,
     pub fcn_last: Option<u64>,
     pub flags: Option<Vec<String>>,
+    #[serde(alias = "addr")]
     pub offset: u64,
     pub opcode: Option<String>,
     pub ptr: Option<u128>,
@@ -100,26 +104,21 @@ pub struct Op {
     pub val: Option<u64>,
 }
 
-// Function to set offset, jump and fail to default values
-fn return_minus_one() -> i64 {
-    -1
-}
-
 #[serde_as]
 #[derive(Serialize, Deserialize, Debug)]
 pub struct ACFJBlock {
-    #[serde(default = "return_minus_one")]
-    pub offset: i64,
-    #[serde(default = "return_minus_one")]
+    #[serde(default = "get_default_addr", alias = "addr")]
+    pub offset: u64,
+    #[serde(default = "get_default_addr")]
     #[serde_as(deserialize_as = "DefaultOnError")]
     // This has been added to eliminate an error where
     // the jump address from x86-64 binaries is larger than
     // an i64.
-    pub jump: i64,
-    #[serde(default = "return_minus_one")]
-    pub fail: i64,
+    pub jump: u64,
+    #[serde(default = "get_default_addr")]
+    pub fail: u64,
     pub ops: Vec<Op>,
-    pub size: Option<i64>,
+    pub size: Option<u64>,
     pub switchop: Option<SwitchOp>,
 }
 
@@ -457,18 +456,18 @@ impl ACFJBlock {
         }
         num_offspring
     }
-    pub fn get_block_edges(&self, bb_start_addrs: &[i64], edge_list: &mut Vec<(u32, u32, u32)>) {
+    pub fn get_block_edges(&self, bb_start_addrs: &[u64], edge_list: &mut Vec<(u32, u32, u32)>) {
         let offset_idx = bb_start_addrs.iter().position(|&p| p == self.offset);
 
         if let Some(offset_idx) = offset_idx {
-            if self.jump != -1 {
+            if self.jump != get_default_addr() {
                 let jump_idx = bb_start_addrs.iter().position(|&p| p == self.jump);
                 if let Some(jump_idx) = jump_idx {
                     edge_list.push((offset_idx as u32, jump_idx as u32, 1));
                 }
             }
 
-            if self.fail != -1 {
+            if self.fail != get_default_addr() {
                 let fail_idx = bb_start_addrs.iter().position(|&p| p == self.fail);
                 if let Some(fail_idx) = fail_idx {
                     edge_list.push((offset_idx as u32, fail_idx as u32, 1));

--- a/src/bb.rs
+++ b/src/bb.rs
@@ -105,7 +105,7 @@ pub struct Op {
 }
 
 #[serde_as]
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct ACFJBlock {
     #[serde(default = "get_default_addr", alias = "addr")]
     pub offset: u64,

--- a/src/combos.rs
+++ b/src/combos.rs
@@ -133,11 +133,11 @@ impl ComboJob {
 #[derive(Default, Hash, PartialEq, Clone, Debug, Deserialize, Serialize)]
 pub struct FinfoTiknib {
     pub name: String,
-    pub edges: i64,
-    pub indegree: i64,
-    pub outdegree: i64,
-    pub nlocals: i64,
-    pub nargs: i64,
+    pub edges: u64,
+    pub indegree: u64,
+    pub outdegree: u64,
+    pub nlocals: u64,
+    pub nargs: u64,
     pub avg_arithshift: OrderedFloat<f32>,
     pub avg_compare: OrderedFloat<f32>,
     pub avg_ctransfer: OrderedFloat<f32>,

--- a/src/extract.rs
+++ b/src/extract.rs
@@ -959,7 +959,7 @@ impl FileToBeProcessed {
             let job_type_suffix = ExtractionJob::get_job_type_suffix(job_type);
             let output_path = self.get_output_filepath(&job_type_suffix).unwrap();
             if Path::new(&output_path).exists() {
-                warn!(
+                debug!(
                     "Skipping {:?} job for {:?}: already processed at {:?}.",
                     job_type_suffix, self.file_path, output_path
                 );

--- a/src/extract.rs
+++ b/src/extract.rs
@@ -55,6 +55,7 @@ pub enum ExtractionJobType {
     LocalVariableXrefs,
     GlobalStrings,
     FunctionBytes,
+    FunctionBytesMasked,
     FunctionZignatures,
 }
 
@@ -74,6 +75,7 @@ static JOB_TYPE_TO_SUFFIX: LazyLock<HashMap<ExtractionJobType, &'static str>> =
             (ExtractionJobType::LocalVariableXrefs, "localvar-xrefs"),
             (ExtractionJobType::GlobalStrings, "strings"),
             (ExtractionJobType::FunctionBytes, "bytes"),
+            (ExtractionJobType::FunctionBytesMasked, "bytes-masked"),
             (ExtractionJobType::FunctionZignatures, "zigs"),
         ])
     });
@@ -445,6 +447,7 @@ pub struct StringEntry {
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct FuncBytes {
     pub bytes: Vec<u8>,
+    pub mask: Option<Vec<u8>>,
 }
 
 // Structs for zj - Function signatures (called "zignatures" in r2)
@@ -696,6 +699,7 @@ impl ExtractionJob {
     fn get_output_extension(job_type: &ExtractionJobType) -> Option<&str> {
         match job_type {
             // Add here if output is not a JSON file (e.g. txt file or directory)
+            ExtractionJobType::FunctionBytes => None, // Output is a directory
             _ => Some("json"),
         }
     }
@@ -739,15 +743,30 @@ impl FunctionToBeProcessed {
         r2p: &mut R2Pipe,
         output_dirpath: &PathBuf,
         filename_template: &str,
+        apply_mask: bool,
     ) -> Result<()> {
-        let func_bytes = self.get_bytes(r2p)?;
-        let output_filepath = self.get_output_filepath(output_dirpath, filename_template, "bin");
-        std::fs::write(&output_filepath, func_bytes.bytes).with_context(|| {
+        let func_bytes = self.get_bytes(r2p, apply_mask).context("Failed to get function bytes")?;
+        let bytes_filepath = self.get_output_filepath(output_dirpath, filename_template, "bin");
+        let masked_bytes_filepath = self.get_output_filepath(output_dirpath, filename_template, "masked.bin");
+        
+        info!("Writing function bytes to file: {:?}", bytes_filepath);
+        std::fs::write(&bytes_filepath, func_bytes.bytes).with_context(|| {
             format!(
                 "Failed to write function bytes to file: {:?}",
-                output_filepath
+                bytes_filepath
             )
         })?;
+
+        if apply_mask {
+            let bytes_mask = func_bytes.mask.context("Failed to get function masked bytes")?;
+            info!("Writing function masked bytes to file: {:?}", masked_bytes_filepath);
+            std::fs::write(&masked_bytes_filepath, bytes_mask).with_context(|| {
+                format!(
+                    "Failed to write function masked bytes to file: {:?}",
+                    masked_bytes_filepath
+                )
+            })?;
+        }
         Ok(())
     }
 
@@ -790,15 +809,24 @@ impl FunctionToBeProcessed {
         output_filepath
     }
 
-    fn get_bytes(&self, r2p: &mut R2Pipe) -> Result<FuncBytes, Error> {
+    fn get_bytes(&self, r2p: &mut R2Pipe, apply_mask: bool) -> Result<FuncBytes, Error> {
         FileToBeProcessed::go_to_address(r2p, self.addr)?;
-        let mut function_bytes = r2p.cmd("p8f")?;
-        function_bytes = function_bytes.trim().to_string();
-        let decoded_bytes = hex::decode(&function_bytes).context("Failed to decode hex bytes")?;
+        let mut function_bytes_and_mask = r2p.cmd("p8fm")?;
+        function_bytes_and_mask = function_bytes_and_mask.trim().to_string();
+        let parts: Vec<&str> = function_bytes_and_mask.split(":").collect();
+        let function_bytes = hex::decode(parts[0]).context("Failed to decode hex function bytes")?;
+        let mut masked_bytes: Option<Vec<u8>> = None;
 
-        Ok(FuncBytes {
-            bytes: decoded_bytes,
-        })
+        if apply_mask {
+            let bytes_mask = hex::decode(parts[1]).context("Failed to decode hex bytes mask")?;
+            let mut masked_bytes_tmp = vec![0; function_bytes.len()];
+            for i in 0..function_bytes.len() {
+                masked_bytes_tmp[i] = function_bytes[i] & bytes_mask[i];
+            }
+            masked_bytes = Some(masked_bytes_tmp);
+        }
+
+        Ok(FuncBytes { bytes: function_bytes, mask: masked_bytes })
     }
 
     fn get_basic_block_info(&self, r2p: &mut R2Pipe) -> Result<BasicBlockInfo, Error> {
@@ -983,7 +1011,8 @@ impl FileToBeProcessed {
             ExtractionJobType::FunctionZignatures => {
                 self.extract_function_zignatures(r2p, &tmp_output_path)
             }
-            ExtractionJobType::FunctionBytes => self.extract_function_bytes(r2p, &tmp_output_path),
+            ExtractionJobType::FunctionBytes => self.extract_function_bytes(r2p, &tmp_output_path, false),
+            ExtractionJobType::FunctionBytesMasked => self.extract_function_bytes(r2p, &tmp_output_path, true),
         }?;
 
         // Apply final output file name when extraction is done
@@ -1389,18 +1418,24 @@ impl FileToBeProcessed {
         Ok(())
     }
 
-    pub fn extract_function_bytes(&self, r2p: &mut R2Pipe, output_path: &PathBuf) -> Result<()> {
+    pub fn extract_function_bytes(&self, r2p: &mut R2Pipe, output_dirpath: &PathBuf, apply_mask: bool) -> Result<()> {
         info!("Starting function bytes extraction");
+        
+        let function_details = self.get_function_name_list(r2p)?;
 
-        let json_raw = r2p.cmd("p8fmj @@f").with_context(|| {
-            format!(
-                "Failed to extract function bytes from {:?}.",
-                self.file_path
-            )
-        })?;
+        if !output_dirpath.is_dir() {
+            std::fs::create_dir_all(&output_dirpath)
+                .with_context(|| format!("Failed to create directory {:?}", output_dirpath))?;
+        }
 
-        self.stream_write_to_json(&json_raw, output_path)
-            .with_context(|| format!("Failed to write function bytes to {:?}.", self.file_path))?;
+        for function_info in function_details {
+            let function = FunctionToBeProcessed::from(function_info);
+            debug!(
+                "Function Name: {} Address: {} Size: {}",
+                function.name, function.addr, function.size
+            );
+            function.write_to_bin(r2p, &output_dirpath, &self.func_filename_template, apply_mask)?;
+        }
 
         info!("Function bytes successfully extracted");
         Ok(())

--- a/src/extract.rs
+++ b/src/extract.rs
@@ -1,5 +1,6 @@
 use crate::afij::AFIJFunctionInfo;
 use crate::agcj::AGCJFunctionCallGraph;
+use crate::agfj::AGFJFunc;
 use crate::utils::sanitize_filename;
 
 use anyhow::anyhow;
@@ -46,6 +47,7 @@ pub enum ExtractionJobType {
     RegisterBehaviour,
     FunctionXrefs,
     CFG,
+    FunctionCFG, // Like CFG, but in a separate file for each function
     CallGraphs,
     FuncInfo,
     FunctionVariables,
@@ -66,6 +68,7 @@ static JOB_TYPE_TO_SUFFIX: LazyLock<HashMap<ExtractionJobType, &'static str>> =
             (ExtractionJobType::RegisterBehaviour, "reg"),
             (ExtractionJobType::FunctionXrefs, "func-xrefs"),
             (ExtractionJobType::CFG, "cfg"),
+            (ExtractionJobType::FunctionCFG, "func-cfg"),
             (ExtractionJobType::CallGraphs, "cg"),
             (ExtractionJobType::FuncInfo, "finfo"),
             (ExtractionJobType::FunctionVariables, "fvars"),
@@ -337,6 +340,17 @@ impl From<AFLJFuncDetails> for FunctionToBeProcessed {
             addr: func_details.offset,
             size: func_details.size,
             ninstrs: func_details.ninstrs,
+        }
+    }
+}
+
+impl From<AGFJFunc> for FunctionToBeProcessed {
+    fn from(func: AGFJFunc) -> Self {
+        FunctionToBeProcessed {
+            name: func.name,
+            addr: func.offset,
+            size: func.size,
+            ninstrs: func.ninstr,
         }
     }
 }
@@ -698,8 +712,9 @@ impl ExtractionJob {
 
     fn get_output_extension(job_type: &ExtractionJobType) -> Option<&str> {
         match job_type {
-            // Add here if output is not a JSON file (e.g. txt file or directory)
-            ExtractionJobType::FunctionBytes => None, // Output is a directory
+            // Add here if output is not a JSON file (e.g. None for a directory)
+            ExtractionJobType::FunctionBytes => None,
+            ExtractionJobType::FunctionCFG => None,
             _ => Some("json"),
         }
     }
@@ -738,6 +753,8 @@ impl ExtractionJob {
 }
 
 impl FunctionToBeProcessed {
+    /// Write function bytes to a binary file with suffix .bin
+    /// If apply_mask is true, write function masked bytes to a binary file with suffix .masked.bin
     fn write_to_bin(
         &self,
         r2p: &mut R2Pipe,
@@ -745,11 +762,14 @@ impl FunctionToBeProcessed {
         filename_template: &str,
         apply_mask: bool,
     ) -> Result<()> {
-        let func_bytes = self.get_bytes(r2p, apply_mask).context("Failed to get function bytes")?;
+        let func_bytes = self
+            .get_bytes(r2p, apply_mask)
+            .context("Failed to get function bytes")?;
         let bytes_filepath = self.get_output_filepath(output_dirpath, filename_template, "bin");
-        let masked_bytes_filepath = self.get_output_filepath(output_dirpath, filename_template, "masked.bin");
-        
-        info!("Writing function bytes to file: {:?}", bytes_filepath);
+        let masked_bytes_filepath =
+            self.get_output_filepath(output_dirpath, filename_template, "masked.bin");
+
+        debug!("Writing function bytes to file: {:?}", bytes_filepath);
         std::fs::write(&bytes_filepath, func_bytes.bytes).with_context(|| {
             format!(
                 "Failed to write function bytes to file: {:?}",
@@ -758,14 +778,55 @@ impl FunctionToBeProcessed {
         })?;
 
         if apply_mask {
-            let bytes_mask = func_bytes.mask.context("Failed to get function masked bytes")?;
-            info!("Writing function masked bytes to file: {:?}", masked_bytes_filepath);
+            let bytes_mask = func_bytes
+                .mask
+                .context("Failed to get function masked bytes")?;
+            debug!(
+                "Writing function masked bytes to file: {:?}",
+                masked_bytes_filepath
+            );
             std::fs::write(&masked_bytes_filepath, bytes_mask).with_context(|| {
                 format!(
                     "Failed to write function masked bytes to file: {:?}",
                     masked_bytes_filepath
                 )
             })?;
+        }
+        Ok(())
+    }
+
+    fn write_to_json(
+        &self,
+        json_obj: &Value,
+        output_dirpath: &PathBuf,
+        filename_template: &str,
+    ) -> Result<()> {
+        let output_filepath = self.get_output_filepath(output_dirpath, filename_template, "json");
+        debug!("Writing JSON to {:?}", output_filepath);
+        let file = File::create(&output_filepath)
+            .with_context(|| format!("Unable to create file {:?}", output_filepath))?;
+        serde_json::to_writer(file, json_obj)
+            .with_context(|| format!("Unable to write JSON to {:?}", output_filepath))?;
+        Ok(())
+    }
+
+    fn write_cfg_to_json(
+        &self,
+        r2p: &mut R2Pipe,
+        output_dirpath: &PathBuf,
+        filename_template: &str,
+    ) -> Result<()> {
+        let cfg = self
+            .get_cfg(r2p)
+            .context(format!("Failed to get CFG @ {}", self.addr))?;
+        // Make sure self.addr and cfg_json.addr are the same
+        if self.addr != cfg.offset {
+            // If they aren't, write the CFG to a JSON file with the other function's details
+            warn!("Function address mismatch: {} != {}", self.addr, cfg.offset);
+            let other_function = FunctionToBeProcessed::from(cfg.clone());
+            other_function.write_to_json(&json!(cfg), output_dirpath, filename_template)?;
+        } else {
+            self.write_to_json(&json!(cfg), output_dirpath, filename_template)?;
         }
         Ok(())
     }
@@ -814,7 +875,8 @@ impl FunctionToBeProcessed {
         let mut function_bytes_and_mask = r2p.cmd("p8fm")?;
         function_bytes_and_mask = function_bytes_and_mask.trim().to_string();
         let parts: Vec<&str> = function_bytes_and_mask.split(":").collect();
-        let function_bytes = hex::decode(parts[0]).context("Failed to decode hex function bytes")?;
+        let function_bytes =
+            hex::decode(parts[0]).context("Failed to decode hex function bytes")?;
         let mut masked_bytes: Option<Vec<u8>> = None;
 
         if apply_mask {
@@ -826,7 +888,10 @@ impl FunctionToBeProcessed {
             masked_bytes = Some(masked_bytes_tmp);
         }
 
-        Ok(FuncBytes { bytes: function_bytes, mask: masked_bytes })
+        Ok(FuncBytes {
+            bytes: function_bytes,
+            mask: masked_bytes,
+        })
     }
 
     fn get_basic_block_info(&self, r2p: &mut R2Pipe) -> Result<BasicBlockInfo, Error> {
@@ -934,6 +999,29 @@ impl FunctionToBeProcessed {
             Ok(parsed_obj)
         }
     }
+
+    fn get_cfg(&self, r2p: &mut R2Pipe) -> Result<AGFJFunc, Error> {
+        FileToBeProcessed::go_to_address(r2p, self.addr)?;
+        debug!("Getting CFG for function @ {}", self.addr);
+        // let json_str = r2p.cmd("agfj").context("Command agfj failed")?;
+        let json = r2p.cmdj("agfj").context("Command agfj failed")?;
+        // let cfg: AGFJFunc = serde_json::from_str(&json_str)
+        //     .with_context(|| format!("Unable to convert {:?} to AGFJFunc struct!", json_str))?;
+
+        // AGFJ returns an array of JSON objects, it should only ever be length 1
+        let cfg: Vec<AGFJFunc> = serde_json::from_value(json.clone())
+            .with_context(|| format!("Unable to convert {:?} to AGFJFunc struct!", json))?;
+        if cfg.len() == 0 {
+            return Err(anyhow!("No CFG found for function @ {}", self.addr));
+        } else if cfg.len() > 1 {
+            warn!(
+                "Multiple CFGs found for function @ {}; ignoring all but the first",
+                self.addr
+            );
+        }
+        let func_cfg = cfg[0].clone();
+        Ok(func_cfg)
+    }
 }
 
 impl FileToBeProcessed {
@@ -993,7 +1081,8 @@ impl FileToBeProcessed {
                 self.extract_register_behaviour(r2p, &tmp_output_path)
             }
             ExtractionJobType::FunctionXrefs => self.extract_function_xrefs(r2p, &tmp_output_path),
-            ExtractionJobType::CFG => self.extract_func_cfgs(r2p, &tmp_output_path),
+            ExtractionJobType::CFG => self.extract_func_cfgs(r2p, &tmp_output_path, false),
+            ExtractionJobType::FunctionCFG => self.extract_func_cfgs(r2p, &tmp_output_path, true),
             ExtractionJobType::CallGraphs => {
                 self.extract_function_call_graphs(r2p, &tmp_output_path)
             }
@@ -1011,8 +1100,12 @@ impl FileToBeProcessed {
             ExtractionJobType::FunctionZignatures => {
                 self.extract_function_zignatures(r2p, &tmp_output_path)
             }
-            ExtractionJobType::FunctionBytes => self.extract_function_bytes(r2p, &tmp_output_path, false),
-            ExtractionJobType::FunctionBytesMasked => self.extract_function_bytes(r2p, &tmp_output_path, true),
+            ExtractionJobType::FunctionBytes => {
+                self.extract_function_bytes(r2p, &tmp_output_path, false)
+            }
+            ExtractionJobType::FunctionBytesMasked => {
+                self.extract_function_bytes(r2p, &tmp_output_path, true)
+            }
         }?;
 
         // Apply final output file name when extraction is done
@@ -1245,15 +1338,68 @@ impl FileToBeProcessed {
         Ok(())
     }
 
-    pub fn extract_func_cfgs(&self, r2p: &mut R2Pipe, output_path: &PathBuf) -> Result<()> {
-        info!("Executing agfj @@f on {:?}", self.file_path);
+    pub fn extract_func_cfgs(
+        &self,
+        r2p: &mut R2Pipe,
+        output_path: &PathBuf,
+        split_by_function: bool,
+    ) -> Result<()> {
+        if !split_by_function {
+            // All CFGs stored in a single JSON file (potentially very large)
+            info!("Executing agfj @@f on {:?}", self.file_path);
 
-        let json_raw = r2p
-            .cmd("agfj @@f")
-            .with_context(|| format!("Failed to extract CFGs from {:?}.", self.file_path))?;
+            let json_raw = r2p
+                .cmd("agfj @@f")
+                .with_context(|| format!("Failed to extract CFGs from {:?}.", self.file_path))?;
 
-        self.stream_write_to_json(&json_raw, output_path)
-            .with_context(|| format!("Failed to write CFGs to {:?}.", self.file_path))?;
+            self.stream_write_to_json(&json_raw, output_path)
+                .with_context(|| format!("Failed to write CFGs to {:?}.", self.file_path))?;
+        } else {
+            // CFGs stored in a separate JSON file for each function
+            info!("Extracting CFGs for each function of {:?}", self.file_path);
+
+            // The output path is a directory, create it if it doesn't exist
+            let output_dirpath = output_path.clone();
+            if !output_dirpath.is_dir() {
+                std::fs::create_dir_all(&output_dirpath)
+                    .with_context(|| format!("Failed to create directory {:?}", output_dirpath))?;
+            }
+
+            // Extract the CFGs for each function
+            for function in self.get_function_name_list(r2p)? {
+                let function = FunctionToBeProcessed::from(function);
+                debug!(
+                    "Extracting CFG for function {:?} @ {:?}",
+                    function.name, function.addr
+                );
+                match function.write_cfg_to_json(r2p, &output_dirpath, &self.func_filename_template)
+                {
+                    Ok(()) => {
+                        debug!(
+                            "Successfully extracted CFG for function {:?} @ {:?}",
+                            function.name, function.addr
+                        );
+                    }
+                    Err(e) => {
+                        let error_path = function.get_output_filepath(
+                            &output_dirpath,
+                            &self.func_filename_template,
+                            "error.log",
+                        );
+                        error!(
+                            "Failed to extract CFG for function {:?} @ {:?}: {}",
+                            function.name, function.addr, e
+                        );
+                        if let Err(write_err) = std::fs::write(&error_path, e.to_string()) {
+                            error!("Failed to write error to {:?}: {}", error_path, write_err);
+                        } else {
+                            info!("Error stored at {:?}", error_path);
+                        }
+                        continue;
+                    }
+                }
+            }
+        }
         Ok(())
     }
 
@@ -1418,9 +1564,14 @@ impl FileToBeProcessed {
         Ok(())
     }
 
-    pub fn extract_function_bytes(&self, r2p: &mut R2Pipe, output_dirpath: &PathBuf, apply_mask: bool) -> Result<()> {
+    pub fn extract_function_bytes(
+        &self,
+        r2p: &mut R2Pipe,
+        output_dirpath: &PathBuf,
+        apply_mask: bool,
+    ) -> Result<()> {
         info!("Starting function bytes extraction");
-        
+
         let function_details = self.get_function_name_list(r2p)?;
 
         if !output_dirpath.is_dir() {
@@ -1434,7 +1585,12 @@ impl FileToBeProcessed {
                 "Function Name: {} Address: {} Size: {}",
                 function.name, function.addr, function.size
             );
-            function.write_to_bin(r2p, &output_dirpath, &self.func_filename_template, apply_mask)?;
+            function.write_to_bin(
+                r2p,
+                &output_dirpath,
+                &self.func_filename_template,
+                apply_mask,
+            )?;
         }
 
         info!("Function bytes successfully extracted");

--- a/src/extract.rs
+++ b/src/extract.rs
@@ -16,7 +16,8 @@ use serde_json;
 
 use glob::glob;
 use md5;
-use serde_json::{json, Deserializer, Value};
+use serde::ser::{SerializeSeq, Serializer};
+use serde_json::{json, value::RawValue, Deserializer, Value};
 use sha1;
 use sha1::Digest as Sha1Digest;
 use sha2::Digest as Sha2Digest;
@@ -25,7 +26,7 @@ use std::collections::HashMap;
 use std::env;
 use std::fs;
 use std::fs::File;
-use std::io::{BufReader, Read};
+use std::io::{BufReader, BufWriter, Read};
 use std::path::PathBuf;
 use std::string::String;
 use std::sync::LazyLock;
@@ -1218,36 +1219,12 @@ impl FileToBeProcessed {
     pub fn extract_func_cfgs(&self, r2p: &mut R2Pipe, output_path: &PathBuf) -> Result<()> {
         info!("Executing agfj @@f on {:?}", self.file_path);
 
-        let json_raw = r2p.cmd("agfj @@f").with_context(|| {
-            format!(
-                "Failed to extract control flow graph information from {:?}.",
-                self.file_path
-            )
-        })?;
+        let json_raw = r2p
+            .cmd("agfj @@f")
+            .with_context(|| format!("Failed to extract CFGs from {:?}.", self.file_path))?;
 
-        info!("Starting JSON fixup for {:?}", self.file_path);
-        match self.fix_json_object(&json_raw) {
-            Ok(json) => {
-                info!("JSON fixup finished for {:?}", self.file_path);
-                // If the cleaned JSON is an empty array, log an error and skip.
-                if json == serde_json::Value::Array(vec![]) {
-                    return Err(anyhow::anyhow!(
-                        "File empty after JSON fixup - Only contains empty JSON array - {:?}",
-                        self.file_path
-                    ));
-                } else {
-                    self.write_to_json(&json, output_path)?;
-                }
-            }
-            Err(e) => {
-                return Err(anyhow::anyhow!(
-                    "Unable to parse json for {:?}: {}: {}",
-                    self.file_path,
-                    json_raw,
-                    e
-                ));
-            }
-        }
+        self.stream_write_to_json(&json_raw, output_path)
+            .with_context(|| format!("Failed to write CFGs to {:?}.", self.file_path))?;
         Ok(())
     }
 
@@ -1521,27 +1498,60 @@ impl FileToBeProcessed {
     }
 
     // Helper Functions
-    fn fix_json_object(&self, json_raw: &str) -> Result<serde_json::Value, serde_json::Error> {
-        // Collect all JSON objects into a vector.
-        let stream = Deserializer::from_str(json_raw).into_iter::<Value>();
-        let json_objects: Result<Vec<Value>, _> = stream
-            .filter_map(|result| {
-                match result {
-                    Ok(Value::Array(ref arr)) if arr.is_empty() => None, // skip empty arrays
-                    other => Some(other),
-                }
-            })
-            .collect();
-        // Map the collected vector into a JSON array.
-        json_objects.map(Value::Array)
-    }
 
+    /// Write a JSON object to a file
     fn write_to_json(&self, json_obj: &Value, output_filepath: &PathBuf) -> Result<()> {
+        info!("Writing JSON to {:?}", output_filepath);
         let file = File::create(&output_filepath)
             .with_context(|| format!("Unable to create file {:?}", output_filepath))?;
         serde_json::to_writer(&file, &json_obj)
             .with_context(|| format!("Failed to write JSON to {:?}", output_filepath))?;
+        info!("JSON written to {:?}", output_filepath);
+        Ok(())
+    }
 
+    /// Stream-parse a concatenated JSON string (e.g. from `agfj @@f`)
+    /// and write the combined results into a single JSON array on disk.
+    /// Unlike `write_to_json`, this never builds a full in-memory Vec<Value>.
+    fn stream_write_to_json(&self, json_raw: &str, output_filepath: &PathBuf) -> Result<()> {
+        info!("Stream writing JSON to {:?}", output_filepath);
+        // Stream the concatenated JSON values
+        let iter = Deserializer::from_str(json_raw).into_iter::<Box<RawValue>>();
+
+        // Stream the final JSON array to disk
+        let file = File::create(output_filepath)
+            .with_context(|| format!("Unable to create file {:?}", output_filepath))?;
+        let mut writer = BufWriter::new(file);
+        let mut ser = serde_json::Serializer::new(&mut writer);
+        let mut seq = ser.serialize_seq(None)?; // unknown length
+
+        for item in iter {
+            match item {
+                Ok(raw) => {
+                    // Skip exactly "[]"
+                    if raw.get().trim() != "[]" {
+                        // RawValue writes the raw JSON without re-encoding
+                        debug!("Serializing JSON chunk");
+                        seq.serialize_element(&raw)?;
+                    } else {
+                        debug!("Skipping empty array");
+                    }
+                }
+                Err(e) => {
+                    // Only tolerate a *trailing* truncation
+                    if e.is_eof() {
+                        warn!("Trailing truncation detected. Stopping stream");
+                        break;
+                    } else {
+                        error!("Malformed JSON chunk: {e}");
+                        return Err(e).context("Malformed JSON chunk");
+                    }
+                }
+            }
+        }
+
+        seq.end()?;
+        info!("JSON stream written to {:?}", output_filepath);
         Ok(())
     }
 

--- a/src/extract.rs
+++ b/src/extract.rs
@@ -1434,7 +1434,36 @@ impl FileToBeProcessed {
                 "Function Name: {} Address: {} Size: {}",
                 function.name, function.addr, function.size
             );
-            function.write_to_bin(r2p, &output_dirpath, &self.func_filename_template, apply_mask)?;
+            match function.write_to_bin(
+                r2p,
+                &output_dirpath,
+                &self.func_filename_template,
+                apply_mask,
+            ) {
+                Ok(()) => {
+                    debug!(
+                        "Successfully extracted bytes for function {:?} @ {:?}",
+                        function.name, function.addr
+                    );
+                }
+                Err(e) => {
+                    let error_path = function.get_output_filepath(
+                        output_dirpath,
+                        &self.func_filename_template,
+                        "error.log",
+                    );
+                    error!(
+                        "Failed to extract bytes for function {:?} @ {:?}: {}",
+                        function.name, function.addr, e
+                    );
+                    if let Err(write_err) = std::fs::write(&error_path, e.to_string()) {
+                        error!("Failed to write error to {:?}: {}", error_path, write_err);
+                    } else {
+                        info!("Error stored at {:?}", error_path);
+                    }
+                    continue;
+                }
+            }
         }
 
         info!("Function bytes successfully extracted");

--- a/src/extract.rs
+++ b/src/extract.rs
@@ -695,7 +695,7 @@ impl ExtractionJob {
 
     fn get_output_extension(job_type: &ExtractionJobType) -> Option<&str> {
         match job_type {
-            ExtractionJobType::FunctionBytes => None, // Output is a directory
+            // Add here if output is not a JSON file (e.g. txt file or directory)
             _ => Some("json"),
         }
     }
@@ -792,7 +792,7 @@ impl FunctionToBeProcessed {
 
     fn get_bytes(&self, r2p: &mut R2Pipe) -> Result<FuncBytes, Error> {
         FileToBeProcessed::go_to_address(r2p, self.addr)?;
-        let mut function_bytes = r2p.cmd(format!("p8 {}", self.size).as_str())?;
+        let mut function_bytes = r2p.cmd("p8f")?;
         function_bytes = function_bytes.trim().to_string();
         let decoded_bytes = hex::decode(&function_bytes).context("Failed to decode hex bytes")?;
 
@@ -1389,23 +1389,19 @@ impl FileToBeProcessed {
         Ok(())
     }
 
-    pub fn extract_function_bytes(&self, r2p: &mut R2Pipe, output_dirpath: &PathBuf) -> Result<()> {
+    pub fn extract_function_bytes(&self, r2p: &mut R2Pipe, output_path: &PathBuf) -> Result<()> {
         info!("Starting function bytes extraction");
-        let function_details = self.get_function_name_list(r2p)?;
 
-        if !output_dirpath.is_dir() {
-            std::fs::create_dir_all(&output_dirpath)
-                .with_context(|| format!("Failed to create directory {:?}", output_dirpath))?;
-        }
+        let json_raw = r2p.cmd("p8fmj @@f").with_context(|| {
+            format!(
+                "Failed to extract function bytes from {:?}.",
+                self.file_path
+            )
+        })?;
 
-        for function_info in function_details {
-            let function = FunctionToBeProcessed::from(function_info);
-            debug!(
-                "Function Name: {} Address: {} Size: {}",
-                function.name, function.addr, function.size
-            );
-            function.write_to_bin(r2p, &output_dirpath, &self.func_filename_template)?;
-        }
+        self.stream_write_to_json(&json_raw, output_path)
+            .with_context(|| format!("Failed to write function bytes to {:?}.", self.file_path))?;
+
         info!("Function bytes successfully extracted");
         Ok(())
     }

--- a/src/extract.rs
+++ b/src/extract.rs
@@ -698,8 +698,9 @@ impl ExtractionJob {
 
     fn get_output_extension(job_type: &ExtractionJobType) -> Option<&str> {
         match job_type {
-            // Add here if output is not a JSON file (e.g. txt file or directory)
-            ExtractionJobType::FunctionBytes => None, // Output is a directory
+            // Add here if output is not a JSON file (None if a directory)
+            ExtractionJobType::FunctionBytes => None,
+            ExtractionJobType::FunctionBytesMasked => None,
             _ => Some("json"),
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -93,6 +93,10 @@ impl fmt::Display for DataType {
 #[derive(Parser)]
 #[command(author, version, about, long_about = None)]
 struct Cli {
+    /// Set the logging level
+    #[arg(short, long, value_name = "LEVEL", default_value = "warn", value_parser = clap::builder::PossibleValuesParser::new(["off", "error", "warn", "info", "debug", "trace"]))]
+    log_level: String,
+
     #[command(subcommand)]
     command: Commands,
 }
@@ -411,12 +415,13 @@ enum DedupSubCommands {
 }
 
 fn main() {
+    let cli = Cli::parse();
+    
     let env = Env::default()
-        .filter_or("LOG_LEVEL", "warn")
+        .filter_or("LOG_LEVEL", &cli.log_level)
         .write_style_or("LOG_STYLE", "always");
 
     env_logger::init_from_env(env);
-    let cli = Cli::parse();
     match &cli.command {
         #[cfg(feature = "goblin")]
         Commands::Info { path } => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -318,6 +318,10 @@ enum Commands {
 
         #[arg(long, default_value = "false")]
         with_annotations: bool,
+
+        /// Toggle to retry previously aborted jobs due to extraction failures
+        #[arg(long, default_value = "false")]
+        retry_aborted: bool,
     },
     /// Generate single embeddings on the fly
     ///
@@ -1067,6 +1071,7 @@ fn main() {
             func_filename,
             timeout,
             with_annotations,
+            retry_aborted,
         } => {
             info!("Creating extraction job with {} modes", modes.len());
             if !output_dir.exists() {
@@ -1085,6 +1090,7 @@ fn main() {
                 func_filename,
                 timeout,
                 with_annotations,
+                retry_aborted,
             )
             .unwrap_or_else(|e| {
                 error!("Failed to create extraction job: {}", e);

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,7 +59,7 @@ use inference::inference;
 #[cfg(feature = "inference")]
 use processors::agfj_graph_embedded_feats;
 use processors::agfj_graph_statistical_features;
-use utils::get_json_paths_from_dir;
+use utils::{get_json_paths_from_dir, validate_func_filename};
 
 #[global_allocator]
 static GLOBAL: MiMalloc = MiMalloc;
@@ -303,6 +303,15 @@ enum Commands {
 
         #[arg(long, default_value = "false")]
         use_curl_pdb: bool,
+
+        /// Name function data files using symbol, address, or custom template
+        #[arg(
+            long,
+            value_name = "TEMPLATE",
+            default_value = "symbol",
+            value_parser = validate_func_filename
+        )]
+        func_filename: String,
 
         #[arg(long)]
         timeout: Option<u64>,
@@ -1055,6 +1064,7 @@ fn main() {
             debug,
             extended_analysis,
             use_curl_pdb,
+            func_filename,
             timeout,
             with_annotations,
         } => {
@@ -1072,6 +1082,7 @@ fn main() {
                 debug,
                 extended_analysis,
                 use_curl_pdb,
+                func_filename,
                 timeout,
                 with_annotations,
             )

--- a/src/main.rs
+++ b/src/main.rs
@@ -308,7 +308,7 @@ enum Commands {
         /// The extraction modes (multiple can be specified)
         #[arg(short, long, value_name = "EXTRACT_MODE",
         value_parser = clap::builder::PossibleValuesParser::new([
-        "bininfo", "finfo", "fvars", "reg", "cfg", "func-xrefs", "cg", "decomp",
+        "bininfo", "finfo", "fvars", "reg", "cfg", "func-cfg", "func-xrefs", "cg", "decomp",
         "pcode-func", "pcode-bb", "localvar-xrefs", "strings", "bytes", "bytes-masked", "zigs"
         ])
         .map(|s| s.parse::<String>().unwrap()),

--- a/src/main.rs
+++ b/src/main.rs
@@ -71,7 +71,10 @@ static MULTI_PROGRESS: std::sync::OnceLock<Arc<MultiProgress>> = std::sync::Once
 
 /// Get the global multi-progress instance
 fn get_multi_progress() -> Arc<MultiProgress> {
-    MULTI_PROGRESS.get().expect("Multi-progress not initialized").clone()
+    MULTI_PROGRESS
+        .get()
+        .expect("Multi-progress not initialized")
+        .clone()
 }
 
 /// Create a progress bar that works with the log bridge
@@ -434,28 +437,31 @@ enum DedupSubCommands {
 
 fn main() {
     let cli = Cli::parse();
-    
+
     // Set up the multi-progress for coordinating progress bars
     let multi = MultiProgress::new();
     let multi_arc = Arc::new(multi);
-    
+
     // Store the multi-progress instance globally
-    MULTI_PROGRESS.set(multi_arc.clone()).expect("Failed to set global multi-progress");
-    
+    MULTI_PROGRESS
+        .set(multi_arc.clone())
+        .expect("Failed to set global multi-progress");
+
     // Build the logger with the specified log level
     let logger = env_logger::Builder::from_env(
         Env::default()
             .filter_or("LOG_LEVEL", &cli.log_level)
-            .write_style_or("LOG_STYLE", "always")
-    ).build();
-    
+            .write_style_or("LOG_STYLE", "always"),
+    )
+    .build();
+
     let level = logger.filter();
-    
+
     // Set up the log bridge to prevent log messages from breaking progress bars
     LogWrapper::new(multi_arc.as_ref().clone(), logger)
         .try_init()
         .expect("Failed to initialize log wrapper");
-    
+
     log::set_max_level(level);
     match &cli.command {
         #[cfg(feature = "goblin")]
@@ -783,8 +789,9 @@ fn main() {
                             .collect::<Vec<_>>();
 
                         let pb = create_progress_bar(combined_cgs_metadata.len() as u64);
-                        combined_cgs_metadata.par_iter().for_each(
-                            |(filepath, metapath)| {
+                        combined_cgs_metadata
+                            .par_iter()
+                            .for_each(|(filepath, metapath)| {
                                 let suffix = format!("{}-meta", graph_type.to_owned());
                                 let full_output_path = get_save_file_path(
                                     &PathBuf::from(filepath),
@@ -871,8 +878,7 @@ fn main() {
                                     )
                                 }
                                 pb.inc(1);
-                            },
-                        );
+                            });
                         pb.finish();
                     }
                 }
@@ -1162,12 +1168,10 @@ fn main() {
 
                 let pb = create_progress_bar(job.files_to_be_processed.len() as u64);
                 // Process all files in parallel, each file processes all modes with a single r2pipe
-                job.files_to_be_processed
-                    .par_iter()
-                    .for_each(|path| {
-                        path.process_all_modes();
-                        pb.inc(1);
-                    });
+                job.files_to_be_processed.par_iter().for_each(|path| {
+                    path.process_all_modes();
+                    pb.inc(1);
+                });
                 pb.finish();
             } else if job.input_path_type == PathType::File {
                 info!("Single file found");

--- a/src/main.rs
+++ b/src/main.rs
@@ -309,7 +309,7 @@ enum Commands {
         #[arg(short, long, value_name = "EXTRACT_MODE",
         value_parser = clap::builder::PossibleValuesParser::new([
         "bininfo", "finfo", "fvars", "reg", "cfg", "func-xrefs", "cg", "decomp",
-        "pcode-func", "pcode-bb", "localvar-xrefs", "strings", "bytes", "zigs"
+        "pcode-func", "pcode-bb", "localvar-xrefs", "strings", "bytes", "bytes-masked", "zigs"
         ])
         .map(|s| s.parse::<String>().unwrap()),
         num_args = 1..,
@@ -330,6 +330,7 @@ enum Commands {
         use_curl_pdb: bool,
 
         /// Name function data files using symbol, address, or custom template
+        /// e.g. '{address}-{symbol}.{ext}'
         #[arg(
             long,
             value_name = "TEMPLATE",

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,6 +1,6 @@
+use regex::Regex;
 use std::fs::create_dir_all;
 use std::path::{Path, PathBuf};
-use regex::Regex;
 use walkdir::WalkDir;
 
 /// Formats a save file path
@@ -85,7 +85,10 @@ pub fn validate_func_filename(s: &str) -> Result<String, String> {
     } else if s.contains("{symbol}") || s.contains("{address}") {
         Ok(s.to_string())
     } else {
-        Err("must be `symbol`, `address`, or a pattern containing `{symbol}`/`{address}`".to_string())
+        Err(
+            "must be `symbol`, `address`, or a pattern containing `{symbol}`/`{address}`"
+                .to_string(),
+        )
     }
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,5 +1,6 @@
 use std::fs::create_dir_all;
 use std::path::{Path, PathBuf};
+use regex::Regex;
 use walkdir::WalkDir;
 
 /// Formats a save file path
@@ -85,6 +86,23 @@ pub fn validate_func_filename(s: &str) -> Result<String, String> {
         Ok(s.to_string())
     } else {
         Err("must be `symbol`, `address`, or a pattern containing `{symbol}`/`{address}`".to_string())
+    }
+}
+
+/// Sanitize name for an output file
+///
+/// This function sanitizes a file name by replacing non-valid characters with '_'.
+pub fn sanitize_filename(name: &str) -> String {
+    // Replace non-valid characters with '_'
+    // Valid characters: letters, digits, '_', '-', and '.'
+    let re = Regex::new(r"[^\w.-]").unwrap();
+    let sanitized_name = re.replace_all(name, "_").into_owned();
+
+    // This is a pretty dirty fix and may break things
+    if sanitized_name.len() > 100 {
+        sanitized_name[..50].to_string() + &sanitized_name[sanitized_name.len() - 50..]
+    } else {
+        sanitized_name
     }
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -74,6 +74,20 @@ pub fn get_save_file_path(
     }
 }
 
+/// Validate the function filename template
+///
+/// This function validates the function filename template to ensure it is a valid template.
+/// The template must be a string containing `{symbol}` or `{address}`.
+pub fn validate_func_filename(s: &str) -> Result<String, String> {
+    if s == "symbol" || s == "address" {
+        Ok(s.to_string())
+    } else if s.contains("{symbol}") || s.contains("{address}") {
+        Ok(s.to_string())
+    } else {
+        Err("must be `symbol`, `address`, or a pattern containing `{symbol}`/`{address}`".to_string())
+    }
+}
+
 /// Get the JSON paths from a directory
 ///
 /// This function takes a path to a directory and traverses all

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -164,6 +164,16 @@ pub fn parse_hex_escapes(s: String) -> Vec<u8> {
     bytes
 }
 
+
+/// Function to return a default address value
+///
+/// This function returns a default address of u64::MAX
+/// This means that the address is not set as it is an impossible address to 
+/// reach, unless the binary is millions of terabytes.
+pub fn get_default_addr() -> u64 {
+    u64::MAX
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -164,11 +164,10 @@ pub fn parse_hex_escapes(s: String) -> Vec<u8> {
     bytes
 }
 
-
 /// Function to return a default address value
 ///
 /// This function returns a default address of u64::MAX
-/// This means that the address is not set as it is an impossible address to 
+/// This means that the address is not set as it is an impossible address to
 /// reach, unless the binary is millions of terabytes.
 pub fn get_default_addr() -> u64 {
     u64::MAX


### PR DESCRIPTION
### Background
There was a JSON truncation issue when extracting CFG data from big files providing a lot of functions. 

The truncation issue has already been solved in `3f9e509`, where instead of aborting the whole extraction, it stores the CFGs until the end of file error is met. Still, this means that the data extraction would be incomplete.

### Summary
This PR introduces the `func-cfg` extraction mode. This is the same data as with the plain `cfg` mode. However, the difference is that the `agfj` command is executed function-by-function and the result is stored in a separate file, following the same procedure as the bytes extraction.

For instance, this new mode can be tested with the following command:
`bin2ml -l debug extract --extended-analysis -f mips64-gcc-7-O3_z3 -o . -m func-cfg --func-filename "{address}-{symbol}.{ext}"`

The output will be a directory called `mips64-gcc-7-O3_z3_func-cfg` containing a set of files as exemplified below:
```
120077938-sym._init.json
1200779c0-sym.error_char_const_.json
120077a3c-sym.std____cxx11__basic_string_char__stdt__std__allocator_char__const___clone_isra72_.json
120077aa8-method.std____cxx11__basic_string_char__const___clone_.isra.34___clone_.constprop.39_.json
120077bbc-method.std____cxx11__basic_string_char__const___clone_.isra.63___clone_.constprop.83_.json
120077cd0-sym.std____cxx11__basic_string_char__stdt__std__allocator_char__const___clone_isra66_.json
120077d3c-method.z3_replayer__imp.kind2string_z3_rayer__imp__value_kind__const__clone_.isra.18_.json
120077e04-sym.void_std____cxx11__basic_string_charst__std__forward_iterator_tag___clone_isra51_.json
120077f0c-sym.std____cxx11__basic_string_char__stdar__const___clone_isra54___clone_constprop59_.json
120078020-method.void_std____cxx11__basic_string_c__std__forward_iterator_tag___clone_.isra.36_.json
```