### PR TITLE
Handle broken pipe

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ rust_search = "2.1.0"
 tch = {version = "0.10.3", optional = true}
 mimalloc = { version = "*", default-features = false }
 indicatif = { version = "0.17.3", features = ["rayon"]}
+indicatif-log-bridge = "0.2.3"
 itertools = "0.10.5"
 prettytable = "0.10.0"
 serde-aux = "4.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ tokenizers = "0.13.2"
 rust_search = "2.1.0"
 tch = {version = "0.10.3", optional = true}
 mimalloc = { version = "*", default-features = false }
-indicatif = { version = "0.17.3", features = ["rayon"]}
+indicatif = { version = "0.17.11", features = ["rayon"]}
 indicatif-log-bridge = "0.2.3"
 itertools = "0.10.5"
 prettytable = "0.10.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ tokenizers = "0.13.2"
 rust_search = "2.1.0"
 tch = {version = "0.10.3", optional = true}
 mimalloc = { version = "*", default-features = false }
-indicatif = { version = "0.17.11", features = ["rayon"]}
+indicatif = { version = "0.18.0", features = ["rayon"]}
 indicatif-log-bridge = "0.2.3"
 itertools = "0.10.5"
 prettytable = "0.10.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 r2pipe = "0.6.0"
 serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0.60"
+serde_json = { version = "1.0.60", features = ["raw_value"] }
 clap = { version = "4.0.29", features = ["derive"] }
 goblin = { version = "0.6.0", optional = true }
 walkdir = "2"

--- a/src/afij.rs
+++ b/src/afij.rs
@@ -8,7 +8,7 @@ use serde_json::Value;
 pub struct AFIJFunctionInfo {
     pub offset: u64,
     pub name: String,
-    pub size: i128,
+    pub size: u64,
     #[serde(rename = "is-pure")]
     pub is_pure: String,
     pub realsz: u64,
@@ -23,21 +23,21 @@ pub struct AFIJFunctionInfo {
     pub nbbs: u64,
     #[serde(rename = "is-lineal")]
     pub is_lineal: bool,
-    pub ninstrs: i64,
-    pub edges: i64,
+    pub ninstrs: u64,
+    pub edges: u64,
     pub ebbs: u64,
     pub signature: String,
     pub minbound: u64,
-    pub maxbound: i128,
+    pub maxbound: u64,
     pub callrefs: Option<Vec<Callref>>,
     // TODO: Need to fix this and change to string instead of i64 to get round large random numbers
     pub datarefs: Option<Vec<Dataref>>,
     pub codexrefs: Option<Vec<Codexref>>,
-    pub dataxrefs: Option<Vec<i64>>,
-    pub indegree: Option<i64>,
-    pub outdegree: Option<i64>,
-    pub nlocals: Option<i64>,
-    pub nargs: Option<i64>,
+    pub dataxrefs: Option<Vec<i64>>, // TODO: Check this data type
+    pub indegree: Option<u64>,
+    pub outdegree: Option<u64>,
+    pub nlocals: Option<u64>,
+    pub nargs: Option<u64>,
     pub bpvars: Option<Vec<Bpvar>>,
     // Cannot find a good example of an spvars yet
     pub spvars: Option<Vec<Value>>,
@@ -103,12 +103,12 @@ pub struct Regvar {
 #[serde(rename_all = "camelCase")]
 pub struct AFIJFeatureSubset {
     pub name: String,
-    pub ninstrs: i64,
-    pub edges: i64,
-    pub indegree: i64,
-    pub outdegree: i64,
-    pub nlocals: i64,
-    pub nargs: i64,
+    pub ninstrs: u64,
+    pub edges: u64,
+    pub indegree: u64,
+    pub outdegree: u64,
+    pub nlocals: u64,
+    pub nargs: u64,
     pub signature: String,
 }
 
@@ -130,12 +130,12 @@ impl From<&AFIJFunctionInfo> for AFIJFeatureSubset {
 #[derive(Default, Debug, Clone, PartialEq, Hash, Serialize, Deserialize)]
 pub struct AFIJFeatureSubsetExtended {
     pub name: String,
-    pub ninstrs: i64,
-    pub edges: i64,
-    pub indegree: i64,
-    pub outdegree: i64,
-    pub nlocals: i64,
-    pub nargs: i64,
+    pub ninstrs: u64,
+    pub edges: u64,
+    pub indegree: u64,
+    pub outdegree: u64,
+    pub nlocals: u64,
+    pub nargs: u64,
     pub nbbs: u64,
     pub avg_ins_bb: OrderedFloat<f32>,
 }

--- a/src/afij.rs
+++ b/src/afij.rs
@@ -28,7 +28,9 @@ pub struct AFIJFunctionInfo {
     pub edges: u64,
     pub ebbs: u64,
     pub signature: String,
+    #[serde(alias = "minaddr")]
     pub minbound: u64,
+    #[serde(alias = "maxaddr")]
     pub maxbound: u64,
     pub callrefs: Option<Vec<Callref>>,
     // TODO: Need to fix this and change to string instead of i64 to get round large random numbers

--- a/src/afij.rs
+++ b/src/afij.rs
@@ -6,6 +6,7 @@ use serde_json::Value;
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AFIJFunctionInfo {
+    #[serde(alias = "addr")]
     pub offset: u64,
     pub name: String,
     pub size: u64,

--- a/src/agcj.rs
+++ b/src/agcj.rs
@@ -3,7 +3,7 @@ use crate::networkx::{
     CallGraphFuncNameNode, CallGraphFuncWithMetadata, CallGraphTikNibFeatures,
     CallGraphTikNibFinfoFeatures, NetworkxDiGraph,
 };
-use crate::utils::{check_or_create_dir, get_save_file_path};
+use crate::utils::{check_or_create_dir, get_save_file_path, sanitize_filename};
 use itertools::Itertools;
 use petgraph::prelude::Graph;
 use serde::{Deserialize, Serialize};
@@ -14,14 +14,14 @@ use std::path::{Path, PathBuf};
 #[serde(rename_all = "camelCase")]
 pub struct AGCJFunctionCallGraph {
     pub name: String,
-    pub size: i64,
+    pub size: u64,
     pub imports: Option<Vec<String>>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct AGCJParsedObjects {
     pub edge_property: String,
-    pub edges: Vec<Vec<i32>>,
+    pub edges: Vec<Vec<u32>>,
     pub node_holes: Vec<String>,
     pub nodes: Vec<String>,
 }
@@ -45,10 +45,7 @@ impl AGCJFunctionCallGraph {
 
         let mut function_name = self.name.clone();
 
-        // This is a pretty dirty fix and may break things
-        if function_name.chars().count() > 100 {
-            function_name = self.name[..75].to_string();
-        }
+        function_name = sanitize_filename(&function_name);
 
         let filename = format!("{}-{}.json", function_name, type_suffix);
 
@@ -82,11 +79,7 @@ impl AGCJFunctionCallGraph {
         check_or_create_dir(&full_output_path);
 
         let mut function_name = self.name.clone();
-
-        // This is a pretty dirty fix and may break things
-        if function_name.chars().count() > 100 {
-            function_name = self.name[..75].to_string();
-        }
+        function_name = sanitize_filename(&function_name);
 
         let filename = format!(
             "{}/{}-{}.json",
@@ -121,11 +114,7 @@ impl AGCJFunctionCallGraph {
         check_or_create_dir(&full_output_path);
 
         let mut function_name = self.name.clone();
-
-        // This is a pretty dirty fix and may break things
-        if function_name.chars().count() > 100 {
-            function_name = self.name[..75].to_string();
-        }
+        function_name = sanitize_filename(&function_name);
 
         let filename = format!(
             "{}/{}-{}.json",
@@ -159,11 +148,7 @@ impl AGCJFunctionCallGraph {
         check_or_create_dir(&full_output_path);
         debug!("Built Path: {:?}", full_output_path);
         let mut function_name = self.name.clone();
-
-        // This is a pretty dirty fix and may break things
-        if function_name.chars().count() > 100 {
-            function_name = self.name[..75].to_string();
-        }
+        function_name = sanitize_filename(&function_name);
 
         let filename = format!("{}-{}.json", function_name, type_suffix);
         // Normalise string for windows

--- a/src/agfj.rs
+++ b/src/agfj.rs
@@ -35,15 +35,15 @@ struct EdgePair {
     wt: u16,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct AGFJFunc {
     pub name: String,
-    nargs: u64,
-    ninstr: u64,
-    nlocals: u64,
     #[serde(alias = "addr")]
-    offset: u64,
-    size: Option<u64>,
+    pub offset: u64,
+    pub size: u64,
+    pub ninstr: u64,
+    nargs: u64,
+    nlocals: u64,
     stack: u64,
     r#type: String,
     pub blocks: Vec<ACFJBlock>,
@@ -794,7 +794,7 @@ mod tests {
         assert_eq!(file.functions.as_ref().unwrap()[0][0].ninstr, 78);
         assert_eq!(file.functions.as_ref().unwrap()[0][0].nargs, 2);
         assert_eq!(file.functions.as_ref().unwrap()[0][0].nlocals, 0);
-        assert_eq!(file.functions.as_ref().unwrap()[0][0].size, Some(334));
+        assert_eq!(file.functions.as_ref().unwrap()[0][0].size, 334);
         assert_eq!(file.functions.as_ref().unwrap()[0][0].stack, 56);
         assert!(!file.functions.as_ref().unwrap()[0][0].blocks.is_empty());
 

--- a/src/agfj.rs
+++ b/src/agfj.rs
@@ -813,7 +813,10 @@ mod tests {
         assert!(!file.functions.as_ref().unwrap()[0][0].blocks[0]
             .ops
             .is_empty());
-        assert_eq!(file.functions.as_ref().unwrap()[0][0].blocks[0].fail, get_default_addr());
+        assert_eq!(
+            file.functions.as_ref().unwrap()[0][0].blocks[0].fail,
+            get_default_addr()
+        );
 
         assert!(file.functions.as_ref().unwrap()[0][0].blocks[0]
             .switchop

--- a/src/agfj.rs
+++ b/src/agfj.rs
@@ -41,12 +41,13 @@ pub struct AGFJFunc {
     nargs: u64,
     ninstr: u64,
     nlocals: u64,
+    #[serde(alias = "addr")]
     offset: u64,
     size: Option<u64>,
     stack: u64,
     r#type: String,
     pub blocks: Vec<ACFJBlock>,
-    addr_idx: Option<Vec<i64>>,
+    addr_idx: Option<Vec<u64>>,
     pub edge_list: Option<Vec<(u32, u32, u32)>>,
     graph: Option<Graph<String, u32>>,
 }
@@ -143,7 +144,7 @@ impl AGFJFunc {
     pub fn create_bb_edge_list(&mut self, min_blocks: &u16) {
         if self.blocks.len() > <u16 as Into<usize>>::into(*min_blocks) && self.blocks[0].offset != 1
         {
-            let bb_start_addrs: Vec<i64> = self.blocks.iter().map(|x| x.offset).collect::<Vec<_>>();
+            let bb_start_addrs: Vec<u64> = self.blocks.iter().map(|x| x.offset).collect::<Vec<_>>();
             let mut edge_list = Vec::<(u32, u32, u32)>::new();
 
             for bb in &self.blocks {
@@ -423,7 +424,7 @@ impl AGFJFunc {
                     }
                 };
 
-                let bb_start_addrs: Vec<i64> =
+                let bb_start_addrs: Vec<u64> =
                     self.blocks.iter().map(|x| x.offset).collect::<Vec<_>>();
 
                 match feature_type {
@@ -606,7 +607,7 @@ impl AGFJFunc {
     }
 
     // Convert string memory address to hex / string
-    fn str_to_hex_node_idxs(graph: &mut Graph<String, u32>, addr_idxs: &[i64]) {
+    fn str_to_hex_node_idxs(graph: &mut Graph<String, u32>, addr_idxs: &[u64]) {
         for idx in graph.node_indices() {
             let i_idx = idx.index();
             let hex = addr_idxs[i_idx];
@@ -732,6 +733,7 @@ impl From<(&String, Vec<TikNibFeaturesBB>)> for TikNibFunc {
 #[cfg(test)]
 mod tests {
     use crate::bb::FeatureType;
+    use crate::utils::get_default_addr;
     use std::path::PathBuf;
 
     use crate::AGFJFile;
@@ -811,7 +813,7 @@ mod tests {
         assert!(!file.functions.as_ref().unwrap()[0][0].blocks[0]
             .ops
             .is_empty());
-        assert_eq!(file.functions.as_ref().unwrap()[0][0].blocks[0].fail, -1);
+        assert_eq!(file.functions.as_ref().unwrap()[0][0].blocks[0].fail, get_default_addr());
 
         assert!(file.functions.as_ref().unwrap()[0][0].blocks[0]
             .switchop

--- a/src/bb.rs
+++ b/src/bb.rs
@@ -2,6 +2,7 @@ use crate::consts::*;
 #[cfg(feature = "inference")]
 use crate::inference::InferenceJob;
 use crate::normalisation::{normalise_disasm_simple, normalise_esil_simple};
+use crate::utils::get_default_addr;
 use serde::{Deserialize, Serialize};
 use serde_aux::prelude::*;
 use serde_json::Value;
@@ -58,8 +59,9 @@ pub enum InstructionMode {
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct SwitchOpCase {
-    pub jump: i64,
-    pub offset: i64,
+    pub jump: u64,
+    #[serde(alias = "addr")]
+    pub offset: u64,
     #[serde(deserialize_with = "deserialize_string_from_number")]
     // This will make it challenging to use downstream but has been
     // added because sometimes it is a VERY large int (bigger than i64).
@@ -74,6 +76,7 @@ pub struct SwitchOp {
     pub defval: u16,
     pub maxval: u16,
     pub minval: u16,
+    #[serde(alias = "addr")]
     pub offset: u64,
 }
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -86,6 +89,7 @@ pub struct Op {
     pub fcn_addr: Option<u64>,
     pub fcn_last: Option<u64>,
     pub flags: Option<Vec<String>>,
+    #[serde(alias = "addr")]
     pub offset: u64,
     pub opcode: Option<String>,
     pub ptr: Option<u128>,
@@ -100,26 +104,21 @@ pub struct Op {
     pub val: Option<u64>,
 }
 
-// Function to set offset, jump and fail to default values
-fn return_minus_one() -> i64 {
-    -1
-}
-
 #[serde_as]
 #[derive(Serialize, Deserialize, Debug)]
 pub struct ACFJBlock {
-    #[serde(default = "return_minus_one")]
-    pub offset: i64,
-    #[serde(default = "return_minus_one")]
+    #[serde(default = "get_default_addr", alias = "addr")]
+    pub offset: u64,
+    #[serde(default = "get_default_addr")]
     #[serde_as(deserialize_as = "DefaultOnError")]
     // This has been added to eliminate an error where
     // the jump address from x86-64 binaries is larger than
     // an i64.
-    pub jump: i64,
-    #[serde(default = "return_minus_one")]
-    pub fail: i64,
+    pub jump: u64,
+    #[serde(default = "get_default_addr")]
+    pub fail: u64,
     pub ops: Vec<Op>,
-    pub size: Option<i64>,
+    pub size: Option<u64>,
     pub switchop: Option<SwitchOp>,
 }
 
@@ -457,18 +456,18 @@ impl ACFJBlock {
         }
         num_offspring
     }
-    pub fn get_block_edges(&self, bb_start_addrs: &[i64], edge_list: &mut Vec<(u32, u32, u32)>) {
+    pub fn get_block_edges(&self, bb_start_addrs: &[u64], edge_list: &mut Vec<(u32, u32, u32)>) {
         let offset_idx = bb_start_addrs.iter().position(|&p| p == self.offset);
 
         if let Some(offset_idx) = offset_idx {
-            if self.jump != -1 {
+            if self.jump != get_default_addr() {
                 let jump_idx = bb_start_addrs.iter().position(|&p| p == self.jump);
                 if let Some(jump_idx) = jump_idx {
                     edge_list.push((offset_idx as u32, jump_idx as u32, 1));
                 }
             }
 
-            if self.fail != -1 {
+            if self.fail != get_default_addr() {
                 let fail_idx = bb_start_addrs.iter().position(|&p| p == self.fail);
                 if let Some(fail_idx) = fail_idx {
                     edge_list.push((offset_idx as u32, fail_idx as u32, 1));

--- a/src/bb.rs
+++ b/src/bb.rs
@@ -105,7 +105,7 @@ pub struct Op {
 }
 
 #[serde_as]
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct ACFJBlock {
     #[serde(default = "get_default_addr", alias = "addr")]
     pub offset: u64,

--- a/src/combos.rs
+++ b/src/combos.rs
@@ -133,11 +133,11 @@ impl ComboJob {
 #[derive(Default, Hash, PartialEq, Clone, Debug, Deserialize, Serialize)]
 pub struct FinfoTiknib {
     pub name: String,
-    pub edges: i64,
-    pub indegree: i64,
-    pub outdegree: i64,
-    pub nlocals: i64,
-    pub nargs: i64,
+    pub edges: u64,
+    pub indegree: u64,
+    pub outdegree: u64,
+    pub nlocals: u64,
+    pub nargs: u64,
     pub avg_arithshift: OrderedFloat<f32>,
     pub avg_compare: OrderedFloat<f32>,
     pub avg_ctransfer: OrderedFloat<f32>,

--- a/src/extract.rs
+++ b/src/extract.rs
@@ -959,7 +959,7 @@ impl FileToBeProcessed {
             let job_type_suffix = ExtractionJob::get_job_type_suffix(job_type);
             let output_path = self.get_output_filepath(&job_type_suffix).unwrap();
             if Path::new(&output_path).exists() {
-                warn!(
+                debug!(
                     "Skipping {:?} job for {:?}: already processed at {:?}.",
                     job_type_suffix, self.file_path, output_path
                 );

--- a/src/extract.rs
+++ b/src/extract.rs
@@ -1671,10 +1671,16 @@ impl FileToBeProcessed {
 
         let file_name = self.get_file_name()?;
         if success_count > 0 {
-            info!("Bytes extracted for {}/{} functions in {:?}", success_count, functions_count, file_name);
+            info!(
+                "Bytes extracted for {}/{} functions in {:?}",
+                success_count, functions_count, file_name
+            );
             Ok(())
         } else {
-            Err(anyhow::anyhow!("Failed to extract bytes for any function in {:?}", file_name))
+            Err(anyhow::anyhow!(
+                "Failed to extract bytes for any function in {:?}",
+                file_name
+            ))
         }
     }
 

--- a/src/extract.rs
+++ b/src/extract.rs
@@ -746,10 +746,13 @@ impl FunctionToBeProcessed {
         filename_template: &str,
         apply_mask: bool,
     ) -> Result<()> {
-        let func_bytes = self.get_bytes(r2p, apply_mask).context("Failed to get function bytes")?;
+        let func_bytes = self
+            .get_bytes(r2p, apply_mask)
+            .context(format!("Failed to get function bytes for {:?} @ {:?}", self.name, self.addr))?;
         let bytes_filepath = self.get_output_filepath(output_dirpath, filename_template, "bin");
-        let masked_bytes_filepath = self.get_output_filepath(output_dirpath, filename_template, "masked.bin");
-        
+        let masked_bytes_filepath =
+            self.get_output_filepath(output_dirpath, filename_template, "masked.bin");
+
         info!("Writing function bytes to file: {:?}", bytes_filepath);
         std::fs::write(&bytes_filepath, func_bytes.bytes).with_context(|| {
             format!(
@@ -759,8 +762,13 @@ impl FunctionToBeProcessed {
         })?;
 
         if apply_mask {
-            let bytes_mask = func_bytes.mask.context("Failed to get function masked bytes")?;
-            info!("Writing function masked bytes to file: {:?}", masked_bytes_filepath);
+            let bytes_mask = func_bytes
+                .mask
+                .context(format!("Failed to get function masked bytes for {:?} @ {:?}", self.name, self.addr))?;
+            info!(
+                "Writing function masked bytes to file: {:?}",
+                masked_bytes_filepath
+            );
             std::fs::write(&masked_bytes_filepath, bytes_mask).with_context(|| {
                 format!(
                     "Failed to write function masked bytes to file: {:?}",
@@ -815,11 +823,30 @@ impl FunctionToBeProcessed {
         let mut function_bytes_and_mask = r2p.cmd("p8fm")?;
         function_bytes_and_mask = function_bytes_and_mask.trim().to_string();
         let parts: Vec<&str> = function_bytes_and_mask.split(":").collect();
-        let function_bytes = hex::decode(parts[0]).context("Failed to decode hex function bytes")?;
+
+        if parts.len() < 2 {
+            return Err(anyhow::anyhow!(
+                "Invalid p8fm output format: expected 'bytes:mask' but got '{}'",
+                function_bytes_and_mask
+            ));
+        }
+
+        let function_bytes =
+            hex::decode(parts[0]).context("Failed to decode hex function bytes")?;
         let mut masked_bytes: Option<Vec<u8>> = None;
 
         if apply_mask {
             let bytes_mask = hex::decode(parts[1]).context("Failed to decode hex bytes mask")?;
+
+            // Ensure function_bytes and bytes_mask have the same length
+            if function_bytes.len() != bytes_mask.len() {
+                return Err(anyhow::anyhow!(
+                    "Function bytes length ({}) and mask length ({}) do not match",
+                    function_bytes.len(),
+                    bytes_mask.len()
+                ));
+            }
+
             let mut masked_bytes_tmp = vec![0; function_bytes.len()];
             for i in 0..function_bytes.len() {
                 masked_bytes_tmp[i] = function_bytes[i] & bytes_mask[i];
@@ -827,7 +854,10 @@ impl FunctionToBeProcessed {
             masked_bytes = Some(masked_bytes_tmp);
         }
 
-        Ok(FuncBytes { bytes: function_bytes, mask: masked_bytes })
+        Ok(FuncBytes {
+            bytes: function_bytes,
+            mask: masked_bytes,
+        })
     }
 
     fn get_basic_block_info(&self, r2p: &mut R2Pipe) -> Result<BasicBlockInfo, Error> {
@@ -1012,8 +1042,12 @@ impl FileToBeProcessed {
             ExtractionJobType::FunctionZignatures => {
                 self.extract_function_zignatures(r2p, &tmp_output_path)
             }
-            ExtractionJobType::FunctionBytes => self.extract_function_bytes(r2p, &tmp_output_path, false),
-            ExtractionJobType::FunctionBytesMasked => self.extract_function_bytes(r2p, &tmp_output_path, true),
+            ExtractionJobType::FunctionBytes => {
+                self.extract_function_bytes(r2p, &tmp_output_path, false)
+            }
+            ExtractionJobType::FunctionBytesMasked => {
+                self.extract_function_bytes(r2p, &tmp_output_path, true)
+            }
         }?;
 
         // Apply final output file name when extraction is done
@@ -1419,9 +1453,14 @@ impl FileToBeProcessed {
         Ok(())
     }
 
-    pub fn extract_function_bytes(&self, r2p: &mut R2Pipe, output_dirpath: &PathBuf, apply_mask: bool) -> Result<()> {
+    pub fn extract_function_bytes(
+        &self,
+        r2p: &mut R2Pipe,
+        output_dirpath: &PathBuf,
+        apply_mask: bool,
+    ) -> Result<()> {
         info!("Starting function bytes extraction");
-        
+
         let function_details = self.get_function_name_list(r2p)?;
 
         if !output_dirpath.is_dir() {

--- a/src/extract.rs
+++ b/src/extract.rs
@@ -55,6 +55,7 @@ pub enum ExtractionJobType {
     LocalVariableXrefs,
     GlobalStrings,
     FunctionBytes,
+    FunctionBytesMasked,
     FunctionZignatures,
 }
 
@@ -74,6 +75,7 @@ static JOB_TYPE_TO_SUFFIX: LazyLock<HashMap<ExtractionJobType, &'static str>> =
             (ExtractionJobType::LocalVariableXrefs, "localvar-xrefs"),
             (ExtractionJobType::GlobalStrings, "strings"),
             (ExtractionJobType::FunctionBytes, "bytes"),
+            (ExtractionJobType::FunctionBytesMasked, "bytes-masked"),
             (ExtractionJobType::FunctionZignatures, "zigs"),
         ])
     });
@@ -445,6 +447,7 @@ pub struct StringEntry {
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct FuncBytes {
     pub bytes: Vec<u8>,
+    pub mask: Option<Vec<u8>>,
 }
 
 // Structs for zj - Function signatures (called "zignatures" in r2)
@@ -696,6 +699,7 @@ impl ExtractionJob {
     fn get_output_extension(job_type: &ExtractionJobType) -> Option<&str> {
         match job_type {
             // Add here if output is not a JSON file (e.g. txt file or directory)
+            ExtractionJobType::FunctionBytes => None, // Output is a directory
             _ => Some("json"),
         }
     }
@@ -739,15 +743,30 @@ impl FunctionToBeProcessed {
         r2p: &mut R2Pipe,
         output_dirpath: &PathBuf,
         filename_template: &str,
+        apply_mask: bool,
     ) -> Result<()> {
-        let func_bytes = self.get_bytes(r2p)?;
-        let output_filepath = self.get_output_filepath(output_dirpath, filename_template, "bin");
-        std::fs::write(&output_filepath, func_bytes.bytes).with_context(|| {
+        let func_bytes = self.get_bytes(r2p, apply_mask).context("Failed to get function bytes")?;
+        let bytes_filepath = self.get_output_filepath(output_dirpath, filename_template, "bin");
+        let masked_bytes_filepath = self.get_output_filepath(output_dirpath, filename_template, "masked.bin");
+        
+        info!("Writing function bytes to file: {:?}", bytes_filepath);
+        std::fs::write(&bytes_filepath, func_bytes.bytes).with_context(|| {
             format!(
                 "Failed to write function bytes to file: {:?}",
-                output_filepath
+                bytes_filepath
             )
         })?;
+
+        if apply_mask {
+            let bytes_mask = func_bytes.mask.context("Failed to get function masked bytes")?;
+            info!("Writing function masked bytes to file: {:?}", masked_bytes_filepath);
+            std::fs::write(&masked_bytes_filepath, bytes_mask).with_context(|| {
+                format!(
+                    "Failed to write function masked bytes to file: {:?}",
+                    masked_bytes_filepath
+                )
+            })?;
+        }
         Ok(())
     }
 
@@ -790,15 +809,24 @@ impl FunctionToBeProcessed {
         output_filepath
     }
 
-    fn get_bytes(&self, r2p: &mut R2Pipe) -> Result<FuncBytes, Error> {
+    fn get_bytes(&self, r2p: &mut R2Pipe, apply_mask: bool) -> Result<FuncBytes, Error> {
         FileToBeProcessed::go_to_address(r2p, self.addr)?;
-        let mut function_bytes = r2p.cmd("p8f")?;
-        function_bytes = function_bytes.trim().to_string();
-        let decoded_bytes = hex::decode(&function_bytes).context("Failed to decode hex bytes")?;
+        let mut function_bytes_and_mask = r2p.cmd("p8fm")?;
+        function_bytes_and_mask = function_bytes_and_mask.trim().to_string();
+        let parts: Vec<&str> = function_bytes_and_mask.split(":").collect();
+        let function_bytes = hex::decode(parts[0]).context("Failed to decode hex function bytes")?;
+        let mut masked_bytes: Option<Vec<u8>> = None;
 
-        Ok(FuncBytes {
-            bytes: decoded_bytes,
-        })
+        if apply_mask {
+            let bytes_mask = hex::decode(parts[1]).context("Failed to decode hex bytes mask")?;
+            let mut masked_bytes_tmp = vec![0; function_bytes.len()];
+            for i in 0..function_bytes.len() {
+                masked_bytes_tmp[i] = function_bytes[i] & bytes_mask[i];
+            }
+            masked_bytes = Some(masked_bytes_tmp);
+        }
+
+        Ok(FuncBytes { bytes: function_bytes, mask: masked_bytes })
     }
 
     fn get_basic_block_info(&self, r2p: &mut R2Pipe) -> Result<BasicBlockInfo, Error> {
@@ -983,7 +1011,8 @@ impl FileToBeProcessed {
             ExtractionJobType::FunctionZignatures => {
                 self.extract_function_zignatures(r2p, &tmp_output_path)
             }
-            ExtractionJobType::FunctionBytes => self.extract_function_bytes(r2p, &tmp_output_path),
+            ExtractionJobType::FunctionBytes => self.extract_function_bytes(r2p, &tmp_output_path, false),
+            ExtractionJobType::FunctionBytesMasked => self.extract_function_bytes(r2p, &tmp_output_path, true),
         }?;
 
         // Apply final output file name when extraction is done
@@ -1389,18 +1418,24 @@ impl FileToBeProcessed {
         Ok(())
     }
 
-    pub fn extract_function_bytes(&self, r2p: &mut R2Pipe, output_path: &PathBuf) -> Result<()> {
+    pub fn extract_function_bytes(&self, r2p: &mut R2Pipe, output_dirpath: &PathBuf, apply_mask: bool) -> Result<()> {
         info!("Starting function bytes extraction");
+        
+        let function_details = self.get_function_name_list(r2p)?;
 
-        let json_raw = r2p.cmd("p8fmj @@f").with_context(|| {
-            format!(
-                "Failed to extract function bytes from {:?}.",
-                self.file_path
-            )
-        })?;
+        if !output_dirpath.is_dir() {
+            std::fs::create_dir_all(&output_dirpath)
+                .with_context(|| format!("Failed to create directory {:?}", output_dirpath))?;
+        }
 
-        self.stream_write_to_json(&json_raw, output_path)
-            .with_context(|| format!("Failed to write function bytes to {:?}.", self.file_path))?;
+        for function_info in function_details {
+            let function = FunctionToBeProcessed::from(function_info);
+            debug!(
+                "Function Name: {} Address: {} Size: {}",
+                function.name, function.addr, function.size
+            );
+            function.write_to_bin(r2p, &output_dirpath, &self.func_filename_template, apply_mask)?;
+        }
 
         info!("Function bytes successfully extracted");
         Ok(())

--- a/src/extract.rs
+++ b/src/extract.rs
@@ -1,5 +1,6 @@
 use crate::afij::AFIJFunctionInfo;
 use crate::agcj::AGCJFunctionCallGraph;
+use crate::agfj::AGFJFunc;
 use crate::utils::sanitize_filename;
 
 use anyhow::anyhow;
@@ -46,6 +47,7 @@ pub enum ExtractionJobType {
     RegisterBehaviour,
     FunctionXrefs,
     CFG,
+    FunctionCFG, // Like CFG, but in a separate file for each function
     CallGraphs,
     FuncInfo,
     FunctionVariables,
@@ -66,6 +68,7 @@ static JOB_TYPE_TO_SUFFIX: LazyLock<HashMap<ExtractionJobType, &'static str>> =
             (ExtractionJobType::RegisterBehaviour, "reg"),
             (ExtractionJobType::FunctionXrefs, "func-xrefs"),
             (ExtractionJobType::CFG, "cfg"),
+            (ExtractionJobType::FunctionCFG, "func-cfg"),
             (ExtractionJobType::CallGraphs, "cg"),
             (ExtractionJobType::FuncInfo, "finfo"),
             (ExtractionJobType::FunctionVariables, "fvars"),
@@ -337,6 +340,17 @@ impl From<AFLJFuncDetails> for FunctionToBeProcessed {
             addr: func_details.offset,
             size: func_details.size,
             ninstrs: func_details.ninstrs,
+        }
+    }
+}
+
+impl From<AGFJFunc> for FunctionToBeProcessed {
+    fn from(func: AGFJFunc) -> Self {
+        FunctionToBeProcessed {
+            name: func.name,
+            addr: func.offset,
+            size: func.size,
+            ninstrs: func.ninstr,
         }
     }
 }
@@ -698,8 +712,9 @@ impl ExtractionJob {
 
     fn get_output_extension(job_type: &ExtractionJobType) -> Option<&str> {
         match job_type {
-            // Add here if output is not a JSON file (e.g. txt file or directory)
-            ExtractionJobType::FunctionBytes => None, // Output is a directory
+            // Add here if output is not a JSON file (e.g. None for a directory)
+            ExtractionJobType::FunctionBytes => None,
+            ExtractionJobType::FunctionCFG => None,
             _ => Some("json"),
         }
     }
@@ -738,6 +753,8 @@ impl ExtractionJob {
 }
 
 impl FunctionToBeProcessed {
+    /// Write function bytes to a binary file with suffix .bin
+    /// If apply_mask is true, write function masked bytes to a binary file with suffix .masked.bin
     fn write_to_bin(
         &self,
         r2p: &mut R2Pipe,
@@ -745,11 +762,14 @@ impl FunctionToBeProcessed {
         filename_template: &str,
         apply_mask: bool,
     ) -> Result<()> {
-        let func_bytes = self.get_bytes(r2p, apply_mask).context("Failed to get function bytes")?;
+        let func_bytes = self
+            .get_bytes(r2p, apply_mask)
+            .context("Failed to get function bytes")?;
         let bytes_filepath = self.get_output_filepath(output_dirpath, filename_template, "bin");
-        let masked_bytes_filepath = self.get_output_filepath(output_dirpath, filename_template, "masked.bin");
-        
-        info!("Writing function bytes to file: {:?}", bytes_filepath);
+        let masked_bytes_filepath =
+            self.get_output_filepath(output_dirpath, filename_template, "masked.bin");
+
+        debug!("Writing function bytes to file: {:?}", bytes_filepath);
         std::fs::write(&bytes_filepath, func_bytes.bytes).with_context(|| {
             format!(
                 "Failed to write function bytes to file: {:?}",
@@ -758,14 +778,55 @@ impl FunctionToBeProcessed {
         })?;
 
         if apply_mask {
-            let bytes_mask = func_bytes.mask.context("Failed to get function masked bytes")?;
-            info!("Writing function masked bytes to file: {:?}", masked_bytes_filepath);
+            let bytes_mask = func_bytes
+                .mask
+                .context("Failed to get function masked bytes")?;
+            debug!(
+                "Writing function masked bytes to file: {:?}",
+                masked_bytes_filepath
+            );
             std::fs::write(&masked_bytes_filepath, bytes_mask).with_context(|| {
                 format!(
                     "Failed to write function masked bytes to file: {:?}",
                     masked_bytes_filepath
                 )
             })?;
+        }
+        Ok(())
+    }
+
+    fn write_to_json(
+        &self,
+        json_obj: &Value,
+        output_dirpath: &PathBuf,
+        filename_template: &str,
+    ) -> Result<()> {
+        let output_filepath = self.get_output_filepath(output_dirpath, filename_template, "json");
+        debug!("Writing JSON to {:?}", output_filepath);
+        let file = File::create(&output_filepath)
+            .with_context(|| format!("Unable to create file {:?}", output_filepath))?;
+        serde_json::to_writer(file, json_obj)
+            .with_context(|| format!("Unable to write JSON to {:?}", output_filepath))?;
+        Ok(())
+    }
+
+    fn write_cfg_to_json(
+        &self,
+        r2p: &mut R2Pipe,
+        output_dirpath: &PathBuf,
+        filename_template: &str,
+    ) -> Result<()> {
+        let cfg = self
+            .get_cfg(r2p)
+            .context(format!("Failed to get CFG @ {}", self.addr))?;
+        // Make sure self.addr and cfg_json.addr are the same
+        if self.addr != cfg.offset {
+            // If they aren't, write the CFG to a JSON file with the other function's details
+            warn!("Function address mismatch: {} != {}", self.addr, cfg.offset);
+            let other_function = FunctionToBeProcessed::from(cfg.clone());
+            other_function.write_to_json(&json!(cfg), output_dirpath, filename_template)?;
+        } else {
+            self.write_to_json(&json!(cfg), output_dirpath, filename_template)?;
         }
         Ok(())
     }
@@ -814,7 +875,8 @@ impl FunctionToBeProcessed {
         let mut function_bytes_and_mask = r2p.cmd("p8fm")?;
         function_bytes_and_mask = function_bytes_and_mask.trim().to_string();
         let parts: Vec<&str> = function_bytes_and_mask.split(":").collect();
-        let function_bytes = hex::decode(parts[0]).context("Failed to decode hex function bytes")?;
+        let function_bytes =
+            hex::decode(parts[0]).context("Failed to decode hex function bytes")?;
         let mut masked_bytes: Option<Vec<u8>> = None;
 
         if apply_mask {
@@ -826,7 +888,10 @@ impl FunctionToBeProcessed {
             masked_bytes = Some(masked_bytes_tmp);
         }
 
-        Ok(FuncBytes { bytes: function_bytes, mask: masked_bytes })
+        Ok(FuncBytes {
+            bytes: function_bytes,
+            mask: masked_bytes,
+        })
     }
 
     fn get_basic_block_info(&self, r2p: &mut R2Pipe) -> Result<BasicBlockInfo, Error> {
@@ -934,6 +999,29 @@ impl FunctionToBeProcessed {
             Ok(parsed_obj)
         }
     }
+
+    fn get_cfg(&self, r2p: &mut R2Pipe) -> Result<AGFJFunc, Error> {
+        FileToBeProcessed::go_to_address(r2p, self.addr)?;
+        debug!("Getting CFG for function @ {}", self.addr);
+        // let json_str = r2p.cmd("agfj").context("Command agfj failed")?;
+        let json = r2p.cmdj("agfj").context("Command agfj failed")?;
+        // let cfg: AGFJFunc = serde_json::from_str(&json_str)
+        //     .with_context(|| format!("Unable to convert {:?} to AGFJFunc struct!", json_str))?;
+
+        // AGFJ returns an array of JSON objects, it should only ever be length 1
+        let cfg: Vec<AGFJFunc> = serde_json::from_value(json.clone())
+            .with_context(|| format!("Unable to convert {:?} to AGFJFunc struct!", json))?;
+        if cfg.len() == 0 {
+            return Err(anyhow!("No CFG found for function @ {}", self.addr));
+        } else if cfg.len() > 1 {
+            warn!(
+                "Multiple CFGs found for function @ {}; ignoring all but the first",
+                self.addr
+            );
+        }
+        let func_cfg = cfg[0].clone();
+        Ok(func_cfg)
+    }
 }
 
 impl FileToBeProcessed {
@@ -993,7 +1081,8 @@ impl FileToBeProcessed {
                 self.extract_register_behaviour(r2p, &tmp_output_path)
             }
             ExtractionJobType::FunctionXrefs => self.extract_function_xrefs(r2p, &tmp_output_path),
-            ExtractionJobType::CFG => self.extract_func_cfgs(r2p, &tmp_output_path),
+            ExtractionJobType::CFG => self.extract_func_cfgs(r2p, &tmp_output_path, false),
+            ExtractionJobType::FunctionCFG => self.extract_func_cfgs(r2p, &tmp_output_path, true),
             ExtractionJobType::CallGraphs => {
                 self.extract_function_call_graphs(r2p, &tmp_output_path)
             }
@@ -1011,8 +1100,12 @@ impl FileToBeProcessed {
             ExtractionJobType::FunctionZignatures => {
                 self.extract_function_zignatures(r2p, &tmp_output_path)
             }
-            ExtractionJobType::FunctionBytes => self.extract_function_bytes(r2p, &tmp_output_path, false),
-            ExtractionJobType::FunctionBytesMasked => self.extract_function_bytes(r2p, &tmp_output_path, true),
+            ExtractionJobType::FunctionBytes => {
+                self.extract_function_bytes(r2p, &tmp_output_path, false)
+            }
+            ExtractionJobType::FunctionBytesMasked => {
+                self.extract_function_bytes(r2p, &tmp_output_path, true)
+            }
         }?;
 
         // Apply final output file name when extraction is done
@@ -1245,15 +1338,68 @@ impl FileToBeProcessed {
         Ok(())
     }
 
-    pub fn extract_func_cfgs(&self, r2p: &mut R2Pipe, output_path: &PathBuf) -> Result<()> {
-        info!("Executing agfj @@f on {:?}", self.file_path);
+    pub fn extract_func_cfgs(
+        &self,
+        r2p: &mut R2Pipe,
+        output_path: &PathBuf,
+        split_by_function: bool,
+    ) -> Result<()> {
+        if !split_by_function {
+            // All CFGs stored in a single JSON file (potentially very large)
+            info!("Executing agfj @@f on {:?}", self.file_path);
 
-        let json_raw = r2p
-            .cmd("agfj @@f")
-            .with_context(|| format!("Failed to extract CFGs from {:?}.", self.file_path))?;
+            let json_raw = r2p
+                .cmd("agfj @@f")
+                .with_context(|| format!("Failed to extract CFGs from {:?}.", self.file_path))?;
 
-        self.stream_write_to_json(&json_raw, output_path)
-            .with_context(|| format!("Failed to write CFGs to {:?}.", self.file_path))?;
+            self.stream_write_to_json(&json_raw, output_path)
+                .with_context(|| format!("Failed to write CFGs to {:?}.", self.file_path))?;
+        } else {
+            // CFGs stored in a separate JSON file for each function
+            info!("Extracting CFGs for each function of {:?}", self.file_path);
+
+            // The output path is a directory, create it if it doesn't exist
+            let output_dirpath = output_path.clone();
+            if !output_dirpath.is_dir() {
+                std::fs::create_dir_all(&output_dirpath)
+                    .with_context(|| format!("Failed to create directory {:?}", output_dirpath))?;
+            }
+
+            // Extract the CFGs for each function
+            for function in self.get_function_name_list(r2p)? {
+                let function = FunctionToBeProcessed::from(function);
+                debug!(
+                    "Extracting CFG for function {:?} @ {:?}",
+                    function.name, function.addr
+                );
+                match function.write_cfg_to_json(r2p, &output_dirpath, &self.func_filename_template)
+                {
+                    Ok(()) => {
+                        debug!(
+                            "Successfully extracted CFG for function {:?} @ {:?}",
+                            function.name, function.addr
+                        );
+                    }
+                    Err(e) => {
+                        let error_path = function.get_output_filepath(
+                            &output_dirpath,
+                            &self.func_filename_template,
+                            "error.log",
+                        );
+                        error!(
+                            "Failed to extract CFG for function {:?} @ {:?}: {}",
+                            function.name, function.addr, e
+                        );
+                        if let Err(write_err) = std::fs::write(&error_path, e.to_string()) {
+                            error!("Failed to write error to {:?}: {}", error_path, write_err);
+                        } else {
+                            info!("Error stored at {:?}", error_path);
+                        }
+                        continue;
+                    }
+                }
+            }
+        }
         Ok(())
     }
 
@@ -1418,9 +1564,14 @@ impl FileToBeProcessed {
         Ok(())
     }
 
-    pub fn extract_function_bytes(&self, r2p: &mut R2Pipe, output_dirpath: &PathBuf, apply_mask: bool) -> Result<()> {
+    pub fn extract_function_bytes(
+        &self,
+        r2p: &mut R2Pipe,
+        output_dirpath: &PathBuf,
+        apply_mask: bool,
+    ) -> Result<()> {
         info!("Starting function bytes extraction");
-        
+
         let function_details = self.get_function_name_list(r2p)?;
 
         if !output_dirpath.is_dir() {
@@ -1434,7 +1585,12 @@ impl FileToBeProcessed {
                 "Function Name: {} Address: {} Size: {}",
                 function.name, function.addr, function.size
             );
-            function.write_to_bin(r2p, &output_dirpath, &self.func_filename_template, apply_mask)?;
+            function.write_to_bin(
+                r2p,
+                &output_dirpath,
+                &self.func_filename_template,
+                apply_mask,
+            )?;
         }
 
         info!("Function bytes successfully extracted");

--- a/src/extract.rs
+++ b/src/extract.rs
@@ -119,11 +119,13 @@ pub struct ExtractionJob {
     pub output_path: PathBuf,
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub struct R2PipeConfig {
     pub debug: bool,
-    pub extended_analysis: bool,
+    pub analysis_mode: String,
     pub use_curl_pdb: bool,
+    pub apply_relocations: bool,
+    pub disable_pseudo_asm: bool,
     pub timeout: Option<u64>,
 }
 
@@ -585,8 +587,10 @@ impl ExtractionJob {
         output_path: &PathBuf,
         modes: &Vec<String>,
         debug: &bool,
-        extended_analysis: &bool,
+        analysis_mode: &str,
         use_curl_pdb: &bool,
+        apply_relocations: &bool,
+        disable_pseudo_asm: &bool,
         func_filename_template: &str,
         timeout: &Option<u64>,
         with_annotations: &bool,
@@ -610,7 +614,9 @@ impl ExtractionJob {
 
         let r2_handle_config = R2PipeConfig {
             debug: *debug,
-            extended_analysis: *extended_analysis,
+            analysis_mode: analysis_mode.to_string(),
+            apply_relocations: *apply_relocations,
+            disable_pseudo_asm: *disable_pseudo_asm,
             use_curl_pdb: *use_curl_pdb,
             timeout: *timeout,
         };
@@ -657,7 +663,7 @@ impl ExtractionJob {
                         file_path: PathBuf::from(f),
                         output_path: output_path.to_owned(),
                         job_types: extraction_job_types.clone(),
-                        r2p_config: r2_handle_config,
+                        r2p_config: r2_handle_config.clone(),
                         with_annotations: *with_annotations,
                         retry_aborted: *retry_aborted,
                         func_filename_template: func_filename_template.to_string(),
@@ -1798,36 +1804,62 @@ impl FileToBeProcessed {
             env::set_var("R2_CURL", "1");
         }
 
-        let opts = if self.r2p_config.debug {
+        let mut args = vec![];
+
+        // Set debug level and verbosity
+        if self.r2p_config.debug {
             debug!("Creating r2 handle with debugging");
-            R2PipeSpawnOptions {
-                exepath: "radare2".to_owned(),
-                args: vec!["-e bin.cache=true", "-e log.level=0", "-e asm.pseudo=true"],
-            }
+            args.push("-e log.level=0");
         } else {
             debug!("Creating r2 handle without debugging");
-            R2PipeSpawnOptions {
-                exepath: "radare2".to_owned(),
-                args: vec![
-                    "-e bin.cache=true",
-                    "-e log.level=1",
-                    "-2",
-                    "-e asm.pseudo=true",
-                ],
-            }
+            args.extend(["-e log.level=1", "-2"]);
+        }
+
+        // Choose between cache or relocations (default is cache)
+        if self.r2p_config.apply_relocations {
+            args.push("-e bin.relocs.apply=true");
+        } else {
+            args.push("-e bin.cache=true");
+        }
+
+        // Set pseudo-disassembly (default is true)
+        if self.r2p_config.disable_pseudo_asm {
+            args.push("-e asm.pseudo=false");
+        } else {
+            args.push("-e asm.pseudo=true");
+        }
+
+        // Set timeout if any
+        if let Some(timeout) = self.r2p_config.timeout {
+            // Convert timeout from seconds to milliseconds
+            let timeout_ms = timeout * 1000;
+            let owned_arg_str = format!("-e anal.timeout={timeout_ms}");
+
+            // Leak the owned String to get a &'static str so the compiler doesn't complain
+            let arg_str: &'static str = Box::leak(owned_arg_str.into_boxed_str());
+            args.push(arg_str);
+        }
+
+        let opts = R2PipeSpawnOptions {
+            exepath: "radare2".to_owned(),
+            args,
         };
 
-        debug!("Attempting to create r2pipe using {:?}", self.file_path);
+        debug!(
+            "Attempting to create r2pipe to analyze {:?} ...",
+            self.file_path
+        );
+        debug!(
+            "->  {:?} {:?} {:?}",
+            opts.exepath,
+            opts.args.join(" "),
+            self.file_path
+        );
         let mut r2p = match R2Pipe::in_session() {
             Some(_) => R2Pipe::open().expect("Unable to open R2Pipe"),
             None => R2Pipe::spawn(self.file_path.to_str().unwrap(), Some(opts))
                 .expect("Failed to spawn new R2Pipe"),
         };
-
-        if let Some(timeout) = self.r2p_config.timeout {
-            r2p.cmd(format!("e anal.timeout={}", timeout).as_str())
-                .expect("Failed to set timeout");
-        }
 
         if self.r2p_config.use_curl_pdb {
             let info = r2p.cmdj("ij");
@@ -1848,22 +1880,18 @@ impl FileToBeProcessed {
     }
 
     fn analyse_r2_pipe(&self, r2p: &mut R2Pipe) {
-        if self.r2p_config.extended_analysis {
-            debug!(
-                "Executing 'aaa' r2 command for {}",
-                self.file_path.display()
-            );
-            r2p.cmd("aaa")
-                .expect("Unable to complete standard analysis!");
-            debug!("'aaa' r2 command complete for {}", self.file_path.display());
-        } else {
-            debug!("Executing 'aa' r2 command for {}", self.file_path.display());
-            r2p.cmd("aa")
-                .expect("Unable to complete standard analysis!");
-            debug!(
-                "'aa' r2 command complete for {:?}",
-                self.file_path.display()
-            );
-        };
+        let analysis_mode = self.r2p_config.analysis_mode.as_str();
+        debug!(
+            "Executing '{}' r2 command for {}",
+            analysis_mode,
+            self.file_path.display()
+        );
+        r2p.cmd(analysis_mode)
+            .expect(&format!("Unable to complete analysis! ({analysis_mode})"));
+        debug!(
+            "'{}' r2 command complete for {}",
+            analysis_mode,
+            self.file_path.display()
+        );
     }
 }

--- a/src/extract.rs
+++ b/src/extract.rs
@@ -1152,13 +1152,13 @@ impl FileToBeProcessed {
             let error_path = output_path.with_extension("error.log");
 
             if output_path.exists() {
-                debug!(
+                info!(
                     "Skipping {:?} job for {:?}: already processed at {:?}.",
                     job_type_suffix, self.file_path, output_path
                 );
                 continue;
             } else if error_path.exists() && !self.retry_aborted {
-                debug!(
+                info!(
                     "Skipping {:?} job for {:?}: already processed and failed. Error log at {:?}.",
                     job_type_suffix, self.file_path, error_path
                 );

--- a/src/extract.rs
+++ b/src/extract.rs
@@ -1487,12 +1487,13 @@ impl FileToBeProcessed {
         info!("Starting function bytes extraction");
 
         let function_details = self.get_function_name_list(r2p)?;
-
+        let functions_count = function_details.len();
         if !output_dirpath.is_dir() {
             std::fs::create_dir_all(&output_dirpath)
                 .with_context(|| format!("Failed to create directory {:?}", output_dirpath))?;
         }
 
+        let mut success_count: u32 = 0;
         for function_info in function_details {
             let function = FunctionToBeProcessed::from(function_info);
             debug!(
@@ -1510,6 +1511,7 @@ impl FileToBeProcessed {
                         "Successfully extracted bytes for function {:?} @ {:?}",
                         function.name, function.addr
                     );
+                    success_count += 1;
                 }
                 Err(e) => {
                     let error_path = function.get_output_filepath(
@@ -1531,8 +1533,13 @@ impl FileToBeProcessed {
             }
         }
 
-        info!("Function bytes successfully extracted");
-        Ok(())
+        let file_name = self.get_file_name()?;
+        if success_count > 0 {
+            info!("Bytes extracted for {}/{} functions in {:?}", success_count, functions_count, file_name);
+            Ok(())
+        } else {
+            Err(anyhow::anyhow!("Failed to extract bytes for any function in {:?}", file_name))
+        }
     }
 
     fn get_checksums(&self) -> Result<ChecksumsEntry, Error> {

--- a/src/extract.rs
+++ b/src/extract.rs
@@ -16,7 +16,8 @@ use serde_json;
 
 use glob::glob;
 use md5;
-use serde_json::{json, Deserializer, Value};
+use serde::ser::{SerializeSeq, Serializer};
+use serde_json::{json, value::RawValue, Deserializer, Value};
 use sha1;
 use sha1::Digest as Sha1Digest;
 use sha2::Digest as Sha2Digest;
@@ -25,7 +26,7 @@ use std::collections::HashMap;
 use std::env;
 use std::fs;
 use std::fs::File;
-use std::io::{BufReader, Read};
+use std::io::{BufReader, BufWriter, Read};
 use std::path::PathBuf;
 use std::string::String;
 use std::sync::LazyLock;
@@ -1218,36 +1219,12 @@ impl FileToBeProcessed {
     pub fn extract_func_cfgs(&self, r2p: &mut R2Pipe, output_path: &PathBuf) -> Result<()> {
         info!("Executing agfj @@f on {:?}", self.file_path);
 
-        let json_raw = r2p.cmd("agfj @@f").with_context(|| {
-            format!(
-                "Failed to extract control flow graph information from {:?}.",
-                self.file_path
-            )
-        })?;
+        let json_raw = r2p
+            .cmd("agfj @@f")
+            .with_context(|| format!("Failed to extract CFGs from {:?}.", self.file_path))?;
 
-        info!("Starting JSON fixup for {:?}", self.file_path);
-        match self.fix_json_object(&json_raw) {
-            Ok(json) => {
-                info!("JSON fixup finished for {:?}", self.file_path);
-                // If the cleaned JSON is an empty array, log an error and skip.
-                if json == serde_json::Value::Array(vec![]) {
-                    return Err(anyhow::anyhow!(
-                        "File empty after JSON fixup - Only contains empty JSON array - {:?}",
-                        self.file_path
-                    ));
-                } else {
-                    self.write_to_json(&json, output_path)?;
-                }
-            }
-            Err(e) => {
-                return Err(anyhow::anyhow!(
-                    "Unable to parse json for {:?}: {}: {}",
-                    self.file_path,
-                    json_raw,
-                    e
-                ));
-            }
-        }
+        self.stream_write_to_json(&json_raw, output_path)
+            .with_context(|| format!("Failed to write CFGs to {:?}.", self.file_path))?;
         Ok(())
     }
 
@@ -1521,27 +1498,60 @@ impl FileToBeProcessed {
     }
 
     // Helper Functions
-    fn fix_json_object(&self, json_raw: &str) -> Result<serde_json::Value, serde_json::Error> {
-        // Collect all JSON objects into a vector.
-        let stream = Deserializer::from_str(json_raw).into_iter::<Value>();
-        let json_objects: Result<Vec<Value>, _> = stream
-            .filter_map(|result| {
-                match result {
-                    Ok(Value::Array(ref arr)) if arr.is_empty() => None, // skip empty arrays
-                    other => Some(other),
-                }
-            })
-            .collect();
-        // Map the collected vector into a JSON array.
-        json_objects.map(Value::Array)
-    }
 
+    /// Write a JSON object to a file
     fn write_to_json(&self, json_obj: &Value, output_filepath: &PathBuf) -> Result<()> {
+        info!("Writing JSON to {:?}", output_filepath);
         let file = File::create(&output_filepath)
             .with_context(|| format!("Unable to create file {:?}", output_filepath))?;
         serde_json::to_writer(&file, &json_obj)
             .with_context(|| format!("Failed to write JSON to {:?}", output_filepath))?;
+        info!("JSON written to {:?}", output_filepath);
+        Ok(())
+    }
 
+    /// Stream-parse a concatenated JSON string (e.g. from `agfj @@f`)
+    /// and write the combined results into a single JSON array on disk.
+    /// Unlike `write_to_json`, this never builds a full in-memory Vec<Value>.
+    fn stream_write_to_json(&self, json_raw: &str, output_filepath: &PathBuf) -> Result<()> {
+        info!("Stream writing JSON to {:?}", output_filepath);
+        // Stream the concatenated JSON values
+        let iter = Deserializer::from_str(json_raw).into_iter::<Box<RawValue>>();
+
+        // Stream the final JSON array to disk
+        let file = File::create(output_filepath)
+            .with_context(|| format!("Unable to create file {:?}", output_filepath))?;
+        let mut writer = BufWriter::new(file);
+        let mut ser = serde_json::Serializer::new(&mut writer);
+        let mut seq = ser.serialize_seq(None)?; // unknown length
+
+        for item in iter {
+            match item {
+                Ok(raw) => {
+                    // Skip exactly "[]"
+                    if raw.get().trim() != "[]" {
+                        // RawValue writes the raw JSON without re-encoding
+                        debug!("Serializing JSON chunk");
+                        seq.serialize_element(&raw)?;
+                    } else {
+                        debug!("Skipping empty array");
+                    }
+                }
+                Err(e) => {
+                    // Only tolerate a *trailing* truncation
+                    if e.is_eof() {
+                        warn!("Trailing truncation detected. Stopping stream");
+                        break;
+                    } else {
+                        error!("Malformed JSON chunk: {e}");
+                        return Err(e).context("Malformed JSON chunk");
+                    }
+                }
+            }
+        }
+
+        seq.end()?;
+        info!("JSON stream written to {:?}", output_filepath);
         Ok(())
     }
 

--- a/src/extract.rs
+++ b/src/extract.rs
@@ -748,7 +748,7 @@ impl FunctionToBeProcessed {
     ) -> Result<()> {
         let func_bytes = self
             .get_bytes(r2p, apply_mask)
-            .context(format!("Failed to get function bytes for {:?} @ {:?}", self.name, self.addr))?;
+            .map_err(|e| anyhow::anyhow!("Failed to get bytes: {}", e))?;
         let bytes_filepath = self.get_output_filepath(output_dirpath, filename_template, "bin");
         let masked_bytes_filepath =
             self.get_output_filepath(output_dirpath, filename_template, "masked.bin");
@@ -764,7 +764,7 @@ impl FunctionToBeProcessed {
         if apply_mask {
             let bytes_mask = func_bytes
                 .mask
-                .context(format!("Failed to get function masked bytes for {:?} @ {:?}", self.name, self.addr))?;
+                .context("Masked bytes missing from get_bytes output")?;
             info!(
                 "Writing function masked bytes to file: {:?}",
                 masked_bytes_filepath
@@ -819,39 +819,64 @@ impl FunctionToBeProcessed {
     }
 
     fn get_bytes(&self, r2p: &mut R2Pipe, apply_mask: bool) -> Result<FuncBytes, Error> {
-        FileToBeProcessed::go_to_address(r2p, self.addr)?;
-        let mut function_bytes_and_mask = r2p.cmd("p8fm")?;
-        function_bytes_and_mask = function_bytes_and_mask.trim().to_string();
-        let parts: Vec<&str> = function_bytes_and_mask.split(":").collect();
-
-        if parts.len() < 2 {
-            return Err(anyhow::anyhow!(
-                "Invalid p8fm output format: expected 'bytes:mask' but got '{}'",
-                function_bytes_and_mask
-            ));
-        }
-
-        let function_bytes =
-            hex::decode(parts[0]).context("Failed to decode hex function bytes")?;
+        let cmd_str;
+        let function_bytes;
+        let function_mask;
+        let function_bytes_and_mask;
         let mut masked_bytes: Option<Vec<u8>> = None;
 
         if apply_mask {
-            let bytes_mask = hex::decode(parts[1]).context("Failed to decode hex bytes mask")?;
+            cmd_str = format!("p8fm @ {}", self.addr);
+            function_bytes_and_mask = r2p
+                .cmd(cmd_str.as_str())
+                .with_context(|| format!("Failed to execute `{}`", cmd_str))?
+                .trim()
+                .to_string();
+            let parts: Vec<&str> = function_bytes_and_mask.split(":").collect();
+
+            if parts.len() < 2 {
+                return Err(anyhow::anyhow!(
+                    "Invalid output format: expected 'bytes:mask'.\n\
+                    Output from `{}`: '{}'",
+                    cmd_str,
+                    function_bytes_and_mask
+                ));
+            }
+            function_bytes = hex::decode(parts[0])
+                .with_context(|| format!("Failed to decode hex function bytes: '{}'", parts[0]))?;
+            function_mask = hex::decode(parts[1])
+                .with_context(|| format!("Failed to decode hex function mask: '{}'", parts[1]))?;
 
             // Ensure function_bytes and bytes_mask have the same length
-            if function_bytes.len() != bytes_mask.len() {
+            if function_bytes.len() != function_mask.len() {
                 return Err(anyhow::anyhow!(
-                    "Function bytes length ({}) and mask length ({}) do not match",
+                    "Function bytes length ({}) and mask length ({}) do not match.\n\
+                    Output from `{}`: '{}'",
                     function_bytes.len(),
-                    bytes_mask.len()
+                    function_mask.len(),
+                    cmd_str,
+                    function_bytes_and_mask
                 ));
             }
 
             let mut masked_bytes_tmp = vec![0; function_bytes.len()];
             for i in 0..function_bytes.len() {
-                masked_bytes_tmp[i] = function_bytes[i] & bytes_mask[i];
+                masked_bytes_tmp[i] = function_bytes[i] & function_mask[i];
             }
             masked_bytes = Some(masked_bytes_tmp);
+        } else {
+            cmd_str = format!("p8f @ {}", self.addr);
+            let function_bytes_str = r2p
+                .cmd(cmd_str.as_str())
+                .with_context(|| format!("Failed to execute `{}`", cmd_str))?
+                .trim()
+                .to_string();
+            function_bytes = hex::decode(function_bytes_str.clone()).with_context(|| {
+                format!(
+                    "Failed to decode hex function bytes: '{}'",
+                    function_bytes_str
+                )
+            })?;
         }
 
         Ok(FuncBytes {
@@ -1499,7 +1524,7 @@ impl FileToBeProcessed {
                     if let Err(write_err) = std::fs::write(&error_path, e.to_string()) {
                         error!("Failed to write error to {:?}: {}", error_path, write_err);
                     } else {
-                        info!("Error stored at {:?}", error_path);
+                        info!("Error stored in {:?}", error_path);
                     }
                     continue;
                 }

--- a/src/extract.rs
+++ b/src/extract.rs
@@ -1215,11 +1215,18 @@ impl FileToBeProcessed {
             }
 
             // Lazily initialize r2p if not already done.
-            let r2p = maybe_r2p.get_or_insert_with(|| {
-                let mut pipe = self.setup_r2_pipe();
-                self.analyse_r2_pipe(&mut pipe);
-                pipe
-            });
+            maybe_r2p = match self.ensure_r2_pipe(maybe_r2p, 5) {
+                Ok(r2p) => Some(r2p),
+                Err(e) => {
+                    error!("Failed to create R2Pipe for {:?}: {e}", self.file_path);
+                    None
+                }
+            };
+            if maybe_r2p.is_none() {
+                // We couldn't create a R2Pipe. We must give up on this file
+                break;
+            }
+            let r2p = maybe_r2p.as_mut().unwrap();
 
             match self.process_mode(r2p, job_type) {
                 Ok(_) => debug!(
@@ -1854,7 +1861,7 @@ impl FileToBeProcessed {
         }
     }
 
-    fn setup_r2_pipe(&self) -> R2Pipe {
+    fn setup_r2_pipe(&self) -> Result<R2Pipe> {
         if self.r2p_config.use_curl_pdb {
             // Docs suggest this is unsafe
             env::set_var("R2_CURL", "1");
@@ -1912,9 +1919,10 @@ impl FileToBeProcessed {
             self.file_path
         );
         let mut r2p = match R2Pipe::in_session() {
-            Some(_) => R2Pipe::open().expect("Unable to open R2Pipe"),
+            Some(_) => R2Pipe::open()
+                .with_context(|| format!("Unable to open R2Pipe for {:?}", self.file_path))?,
             None => R2Pipe::spawn(self.file_path.to_str().unwrap(), Some(opts))
-                .expect("Failed to spawn new R2Pipe"),
+                .with_context(|| format!("Failed to spawn new R2Pipe for {:?}", self.file_path))?,
         };
 
         if self.r2p_config.use_curl_pdb {
@@ -1926,16 +1934,19 @@ impl FileToBeProcessed {
                     let ret = self.handle_symbols_pdb(&mut r2p);
 
                     if ret.is_err() {
-                        error!("Unable to get PDB info")
+                        warn!("Unable to get PDB info for {:?}", self.file_path);
+                        info!("Continuing with analysis...");
+                    } else {
+                        info!("PDB info obtained successfully for {:?}", self.file_path);
                     }
                 }
             }
         }
 
-        r2p
+        Ok(r2p)
     }
 
-    fn analyse_r2_pipe(&self, r2p: &mut R2Pipe) {
+    fn analyse_r2_pipe(&self, r2p: &mut R2Pipe) -> Result<()> {
         let analysis_mode = self.r2p_config.analysis_mode.as_str();
         debug!(
             "Executing '{}' r2 command for {}",
@@ -1943,11 +1954,58 @@ impl FileToBeProcessed {
             self.file_path.display()
         );
         r2p.cmd(analysis_mode)
-            .expect(&format!("Unable to complete analysis! ({analysis_mode})"));
+            .with_context(|| format!("Unable to complete analysis! ({analysis_mode})"))?;
         debug!(
             "'{}' r2 command complete for {}",
             analysis_mode,
             self.file_path.display()
+        );
+        Ok(())
+    }
+
+    fn is_r2_pipe_alive(&self, r2p: &mut R2Pipe) -> bool {
+        // Check if we can get the version
+        match r2p.cmd("?V") {
+            Ok(_) => true,   // The R2Pipe is alive
+            Err(_) => false, // The R2Pipe is dead
+        }
+    }
+
+    fn ensure_r2_pipe(&self, maybe_r2p: Option<R2Pipe>, max_attempts: u16) -> Result<R2Pipe> {
+        match maybe_r2p {
+            Some(r2p) => {
+                let mut mutable_r2p = r2p;
+                if self.is_r2_pipe_alive(&mut mutable_r2p) {
+                    return Ok(mutable_r2p);
+                } else {
+                    return self.ensure_r2_pipe(None, max_attempts);
+                }
+            }
+            None => {
+                let mut n_attempts: u16 = 1;
+                while n_attempts <= max_attempts {
+                    info!("Creating R2Pipe (attempt {n_attempts}/{max_attempts})...");
+                    match self.setup_r2_pipe() {
+                        Ok(r2p) => {
+                            let mut mutable_r2p = r2p;
+                            self.analyse_r2_pipe(&mut mutable_r2p)?;
+                            if self.is_r2_pipe_alive(&mut mutable_r2p) {
+                                return Ok(mutable_r2p);
+                            }
+                        }
+                        Err(e) => {
+                            warn!("Failed to create R2Pipe: {e}");
+                            n_attempts += 1;
+                            continue;
+                        }
+                    }
+                }
+            }
+        }
+
+        bail!(
+            "Failed to create R2Pipe after {} attempts. Giving up.",
+            max_attempts
         );
     }
 }

--- a/src/extract.rs
+++ b/src/extract.rs
@@ -1434,7 +1434,36 @@ impl FileToBeProcessed {
                 "Function Name: {} Address: {} Size: {}",
                 function.name, function.addr, function.size
             );
-            function.write_to_bin(r2p, &output_dirpath, &self.func_filename_template, apply_mask)?;
+            match function.write_to_bin(
+                r2p,
+                &output_dirpath,
+                &self.func_filename_template,
+                apply_mask,
+            ) {
+                Ok(()) => {
+                    debug!(
+                        "Successfully extracted bytes for function {:?} @ {:?}",
+                        function.name, function.addr
+                    );
+                }
+                Err(e) => {
+                    let error_path = function.get_output_filepath(
+                        output_dirpath,
+                        &self.func_filename_template,
+                        "error.log",
+                    );
+                    error!(
+                        "Failed to extract bytes for function {:?} @ {:?}: {}",
+                        function.name, function.addr, e
+                    );
+                    if let Err(write_err) = std::fs::write(&error_path, e.to_string()) {
+                        error!("Failed to write error to {:?}: {}", error_path, write_err);
+                    } else {
+                        info!("Error stored at {:?}", error_path);
+                    }
+                    continue;
+                }
+            }
         }
 
         info!("Function bytes successfully extracted");

--- a/src/extract.rs
+++ b/src/extract.rs
@@ -695,7 +695,7 @@ impl ExtractionJob {
 
     fn get_output_extension(job_type: &ExtractionJobType) -> Option<&str> {
         match job_type {
-            ExtractionJobType::FunctionBytes => None, // Output is a directory
+            // Add here if output is not a JSON file (e.g. txt file or directory)
             _ => Some("json"),
         }
     }
@@ -792,7 +792,7 @@ impl FunctionToBeProcessed {
 
     fn get_bytes(&self, r2p: &mut R2Pipe) -> Result<FuncBytes, Error> {
         FileToBeProcessed::go_to_address(r2p, self.addr)?;
-        let mut function_bytes = r2p.cmd(format!("p8 {}", self.size).as_str())?;
+        let mut function_bytes = r2p.cmd("p8f")?;
         function_bytes = function_bytes.trim().to_string();
         let decoded_bytes = hex::decode(&function_bytes).context("Failed to decode hex bytes")?;
 
@@ -1389,23 +1389,19 @@ impl FileToBeProcessed {
         Ok(())
     }
 
-    pub fn extract_function_bytes(&self, r2p: &mut R2Pipe, output_dirpath: &PathBuf) -> Result<()> {
+    pub fn extract_function_bytes(&self, r2p: &mut R2Pipe, output_path: &PathBuf) -> Result<()> {
         info!("Starting function bytes extraction");
-        let function_details = self.get_function_name_list(r2p)?;
 
-        if !output_dirpath.is_dir() {
-            std::fs::create_dir_all(&output_dirpath)
-                .with_context(|| format!("Failed to create directory {:?}", output_dirpath))?;
-        }
+        let json_raw = r2p.cmd("p8fmj @@f").with_context(|| {
+            format!(
+                "Failed to extract function bytes from {:?}.",
+                self.file_path
+            )
+        })?;
 
-        for function_info in function_details {
-            let function = FunctionToBeProcessed::from(function_info);
-            debug!(
-                "Function Name: {} Address: {} Size: {}",
-                function.name, function.addr, function.size
-            );
-            function.write_to_bin(r2p, &output_dirpath, &self.func_filename_template)?;
-        }
+        self.stream_write_to_json(&json_raw, output_path)
+            .with_context(|| format!("Failed to write function bytes to {:?}.", self.file_path))?;
+
         info!("Function bytes successfully extracted");
         Ok(())
     }

--- a/src/extract.rs
+++ b/src/extract.rs
@@ -698,8 +698,9 @@ impl ExtractionJob {
 
     fn get_output_extension(job_type: &ExtractionJobType) -> Option<&str> {
         match job_type {
-            // Add here if output is not a JSON file (e.g. txt file or directory)
-            ExtractionJobType::FunctionBytes => None, // Output is a directory
+            // Add here if output is not a JSON file (None if a directory)
+            ExtractionJobType::FunctionBytes => None,
+            ExtractionJobType::FunctionBytesMasked => None,
             _ => Some("json"),
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -93,6 +93,10 @@ impl fmt::Display for DataType {
 #[derive(Parser)]
 #[command(author, version, about, long_about = None)]
 struct Cli {
+    /// Set the logging level
+    #[arg(short, long, value_name = "LEVEL", default_value = "warn", value_parser = clap::builder::PossibleValuesParser::new(["off", "error", "warn", "info", "debug", "trace"]))]
+    log_level: String,
+
     #[command(subcommand)]
     command: Commands,
 }
@@ -411,12 +415,13 @@ enum DedupSubCommands {
 }
 
 fn main() {
+    let cli = Cli::parse();
+    
     let env = Env::default()
-        .filter_or("LOG_LEVEL", "warn")
+        .filter_or("LOG_LEVEL", &cli.log_level)
         .write_style_or("LOG_STYLE", "always");
 
     env_logger::init_from_env(env);
-    let cli = Cli::parse();
     match &cli.command {
         #[cfg(feature = "goblin")]
         Commands::Info { path } => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -318,6 +318,10 @@ enum Commands {
 
         #[arg(long, default_value = "false")]
         with_annotations: bool,
+
+        /// Toggle to retry previously aborted jobs due to extraction failures
+        #[arg(long, default_value = "false")]
+        retry_aborted: bool,
     },
     /// Generate single embeddings on the fly
     ///
@@ -1067,6 +1071,7 @@ fn main() {
             func_filename,
             timeout,
             with_annotations,
+            retry_aborted,
         } => {
             info!("Creating extraction job with {} modes", modes.len());
             if !output_dir.exists() {
@@ -1085,6 +1090,7 @@ fn main() {
                 func_filename,
                 timeout,
                 with_annotations,
+                retry_aborted,
             )
             .unwrap_or_else(|e| {
                 error!("Failed to create extraction job: {}", e);

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,7 +59,7 @@ use inference::inference;
 #[cfg(feature = "inference")]
 use processors::agfj_graph_embedded_feats;
 use processors::agfj_graph_statistical_features;
-use utils::get_json_paths_from_dir;
+use utils::{get_json_paths_from_dir, validate_func_filename};
 
 #[global_allocator]
 static GLOBAL: MiMalloc = MiMalloc;
@@ -303,6 +303,15 @@ enum Commands {
 
         #[arg(long, default_value = "false")]
         use_curl_pdb: bool,
+
+        /// Name function data files using symbol, address, or custom template
+        #[arg(
+            long,
+            value_name = "TEMPLATE",
+            default_value = "symbol",
+            value_parser = validate_func_filename
+        )]
+        func_filename: String,
 
         #[arg(long)]
         timeout: Option<u64>,
@@ -1055,6 +1064,7 @@ fn main() {
             debug,
             extended_analysis,
             use_curl_pdb,
+            func_filename,
             timeout,
             with_annotations,
         } => {
@@ -1072,6 +1082,7 @@ fn main() {
                 debug,
                 extended_analysis,
                 use_curl_pdb,
+                func_filename,
                 timeout,
                 with_annotations,
             )

--- a/src/main.rs
+++ b/src/main.rs
@@ -308,7 +308,7 @@ enum Commands {
         /// The extraction modes (multiple can be specified)
         #[arg(short, long, value_name = "EXTRACT_MODE",
         value_parser = clap::builder::PossibleValuesParser::new([
-        "bininfo", "finfo", "fvars", "reg", "cfg", "func-xrefs", "cg", "decomp",
+        "bininfo", "finfo", "fvars", "reg", "cfg", "func-cfg", "func-xrefs", "cg", "decomp",
         "pcode-func", "pcode-bb", "localvar-xrefs", "strings", "bytes", "bytes-masked", "zigs"
         ])
         .map(|s| s.parse::<String>().unwrap()),

--- a/src/main.rs
+++ b/src/main.rs
@@ -71,7 +71,10 @@ static MULTI_PROGRESS: std::sync::OnceLock<Arc<MultiProgress>> = std::sync::Once
 
 /// Get the global multi-progress instance
 fn get_multi_progress() -> Arc<MultiProgress> {
-    MULTI_PROGRESS.get().expect("Multi-progress not initialized").clone()
+    MULTI_PROGRESS
+        .get()
+        .expect("Multi-progress not initialized")
+        .clone()
 }
 
 /// Create a progress bar that works with the log bridge
@@ -434,28 +437,31 @@ enum DedupSubCommands {
 
 fn main() {
     let cli = Cli::parse();
-    
+
     // Set up the multi-progress for coordinating progress bars
     let multi = MultiProgress::new();
     let multi_arc = Arc::new(multi);
-    
+
     // Store the multi-progress instance globally
-    MULTI_PROGRESS.set(multi_arc.clone()).expect("Failed to set global multi-progress");
-    
+    MULTI_PROGRESS
+        .set(multi_arc.clone())
+        .expect("Failed to set global multi-progress");
+
     // Build the logger with the specified log level
     let logger = env_logger::Builder::from_env(
         Env::default()
             .filter_or("LOG_LEVEL", &cli.log_level)
-            .write_style_or("LOG_STYLE", "always")
-    ).build();
-    
+            .write_style_or("LOG_STYLE", "always"),
+    )
+    .build();
+
     let level = logger.filter();
-    
+
     // Set up the log bridge to prevent log messages from breaking progress bars
     LogWrapper::new(multi_arc.as_ref().clone(), logger)
         .try_init()
         .expect("Failed to initialize log wrapper");
-    
+
     log::set_max_level(level);
     match &cli.command {
         #[cfg(feature = "goblin")]
@@ -783,8 +789,9 @@ fn main() {
                             .collect::<Vec<_>>();
 
                         let pb = create_progress_bar(combined_cgs_metadata.len() as u64);
-                        combined_cgs_metadata.par_iter().for_each(
-                            |(filepath, metapath)| {
+                        combined_cgs_metadata
+                            .par_iter()
+                            .for_each(|(filepath, metapath)| {
                                 let suffix = format!("{}-meta", graph_type.to_owned());
                                 let full_output_path = get_save_file_path(
                                     &PathBuf::from(filepath),
@@ -871,8 +878,7 @@ fn main() {
                                     )
                                 }
                                 pb.inc(1);
-                            },
-                        );
+                            });
                         pb.finish();
                     }
                 }
@@ -1162,12 +1168,10 @@ fn main() {
 
                 let pb = create_progress_bar(job.files_to_be_processed.len() as u64);
                 // Process all files in parallel, each file processes all modes with a single r2pipe
-                job.files_to_be_processed
-                    .par_iter()
-                    .for_each(|path| {
-                        path.process_all_modes();
-                        pb.inc(1);
-                    });
+                job.files_to_be_processed.par_iter().for_each(|path| {
+                    path.process_all_modes();
+                    pb.inc(1);
+                });
                 pb.finish();
             } else if job.input_path_type == PathType::File {
                 info!("Single file found");

--- a/src/main.rs
+++ b/src/main.rs
@@ -309,7 +309,7 @@ enum Commands {
         #[arg(short, long, value_name = "EXTRACT_MODE",
         value_parser = clap::builder::PossibleValuesParser::new([
         "bininfo", "finfo", "fvars", "reg", "cfg", "func-xrefs", "cg", "decomp",
-        "pcode-func", "pcode-bb", "localvar-xrefs", "strings", "bytes", "zigs"
+        "pcode-func", "pcode-bb", "localvar-xrefs", "strings", "bytes", "bytes-masked", "zigs"
         ])
         .map(|s| s.parse::<String>().unwrap()),
         num_args = 1..,
@@ -330,6 +330,7 @@ enum Commands {
         use_curl_pdb: bool,
 
         /// Name function data files using symbol, address, or custom template
+        /// e.g. '{address}-{symbol}.{ext}'
         #[arg(
             long,
             value_name = "TEMPLATE",

--- a/src/main.rs
+++ b/src/main.rs
@@ -327,8 +327,19 @@ enum Commands {
         extended_analysis: bool,
 
         #[arg(long, default_value = "false")]
+        experimental_analysis: bool,
+
+        #[arg(long, default_value = "false")]
         use_curl_pdb: bool,
 
+        /// Toggle to apply relocations instead of caching (slower but more accurate)
+        #[arg(long, default_value = "false")]
+        apply_relocations: bool, // Open r2 with bin.relocs.apply=true
+        // Otherwise defaults to bin.cache=true
+        /// Toggle to disable pseudo-disassembly (faster but more variable in cross-platform scenarios)
+        #[arg(long, default_value = "false")]
+        disable_pseudo_asm: bool, // Open r2 with asm.pseudo=false
+        // Otherwise defaults to asm.pseudo=true
         /// Name function data files using symbol, address, or custom template
         /// e.g. '{address}-{symbol}.{ext}'
         #[arg(
@@ -339,6 +350,7 @@ enum Commands {
         )]
         func_filename: String,
 
+        /// Timeout for Radare2 analysis in seconds
         #[arg(long)]
         timeout: Option<u64>,
 
@@ -1123,7 +1135,10 @@ fn main() {
             num_threads,
             debug,
             extended_analysis,
+            experimental_analysis,
             use_curl_pdb,
+            apply_relocations,
+            disable_pseudo_asm,
             func_filename,
             timeout,
             with_annotations,
@@ -1135,14 +1150,30 @@ fn main() {
                 exit(1)
             }
 
+            let analysis_mode;
+            // Make sure that extended analysis and experimental analysis are not both true
+            if *extended_analysis && *experimental_analysis {
+                error!("Extended analysis and experimental analysis cannot be both true");
+                exit(1)
+            } else if *extended_analysis {
+                analysis_mode = "aaa";
+            } else if *experimental_analysis {
+                analysis_mode = "aaaa";
+            } else {
+                // Neither are true, so use the default analysis mode
+                analysis_mode = "aa";
+            }
+
             // Create a single extraction job with all modes
             let job = ExtractionJob::new(
                 fpath,
                 output_dir,
                 modes,
                 debug,
-                extended_analysis,
+                analysis_mode,
                 use_curl_pdb,
+                apply_relocations,
+                disable_pseudo_asm,
                 func_filename,
                 timeout,
                 with_annotations,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,6 +1,6 @@
+use regex::Regex;
 use std::fs::create_dir_all;
 use std::path::{Path, PathBuf};
-use regex::Regex;
 use walkdir::WalkDir;
 
 /// Formats a save file path
@@ -85,7 +85,10 @@ pub fn validate_func_filename(s: &str) -> Result<String, String> {
     } else if s.contains("{symbol}") || s.contains("{address}") {
         Ok(s.to_string())
     } else {
-        Err("must be `symbol`, `address`, or a pattern containing `{symbol}`/`{address}`".to_string())
+        Err(
+            "must be `symbol`, `address`, or a pattern containing `{symbol}`/`{address}`"
+                .to_string(),
+        )
     }
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,5 +1,6 @@
 use std::fs::create_dir_all;
 use std::path::{Path, PathBuf};
+use regex::Regex;
 use walkdir::WalkDir;
 
 /// Formats a save file path
@@ -85,6 +86,23 @@ pub fn validate_func_filename(s: &str) -> Result<String, String> {
         Ok(s.to_string())
     } else {
         Err("must be `symbol`, `address`, or a pattern containing `{symbol}`/`{address}`".to_string())
+    }
+}
+
+/// Sanitize name for an output file
+///
+/// This function sanitizes a file name by replacing non-valid characters with '_'.
+pub fn sanitize_filename(name: &str) -> String {
+    // Replace non-valid characters with '_'
+    // Valid characters: letters, digits, '_', '-', and '.'
+    let re = Regex::new(r"[^\w.-]").unwrap();
+    let sanitized_name = re.replace_all(name, "_").into_owned();
+
+    // This is a pretty dirty fix and may break things
+    if sanitized_name.len() > 100 {
+        sanitized_name[..50].to_string() + &sanitized_name[sanitized_name.len() - 50..]
+    } else {
+        sanitized_name
     }
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -74,6 +74,20 @@ pub fn get_save_file_path(
     }
 }
 
+/// Validate the function filename template
+///
+/// This function validates the function filename template to ensure it is a valid template.
+/// The template must be a string containing `{symbol}` or `{address}`.
+pub fn validate_func_filename(s: &str) -> Result<String, String> {
+    if s == "symbol" || s == "address" {
+        Ok(s.to_string())
+    } else if s.contains("{symbol}") || s.contains("{address}") {
+        Ok(s.to_string())
+    } else {
+        Err("must be `symbol`, `address`, or a pattern containing `{symbol}`/`{address}`".to_string())
+    }
+}
+
 /// Get the JSON paths from a directory
 ///
 /// This function takes a path to a directory and traverses all

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -164,6 +164,16 @@ pub fn parse_hex_escapes(s: String) -> Vec<u8> {
     bytes
 }
 
+
+/// Function to return a default address value
+///
+/// This function returns a default address of u64::MAX
+/// This means that the address is not set as it is an impossible address to 
+/// reach, unless the binary is millions of terabytes.
+pub fn get_default_addr() -> u64 {
+    u64::MAX
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -164,11 +164,10 @@ pub fn parse_hex_escapes(s: String) -> Vec<u8> {
     bytes
 }
 
-
 /// Function to return a default address value
 ///
 /// This function returns a default address of u64::MAX
-/// This means that the address is not set as it is an impossible address to 
+/// This means that the address is not set as it is an impossible address to
 /// reach, unless the binary is millions of terabytes.
 pub fn get_default_addr() -> u64 {
     u64::MAX


### PR DESCRIPTION
When R2Pipe becomes no longer functional, all the extraction modes are skipped. This PR fixes this, but checking if the pipe is still alive when another mode is being processed. If it isn't, it tries to reopen it 5 times before giving up on the file.